### PR TITLE
fix: replace per-package releases with single unified release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@goodie-ts/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,32 @@ jobs:
       - run: pnpm test
 
       - name: Create Release PR or Publish
+        id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm release
+          publish: bash scripts/publish.sh
           title: "chore: version packages"
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ""
+
+      - name: Create unified GitHub release
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          VERSION=$(node -p "require('./packages/core/package.json').version")
+          TAG="v${VERSION}"
+
+          # Collect changelog entries from all packages
+          BODY="## Packages published\n"
+          for pkg in packages/*/; do
+            NAME=$(node -p "require('./${pkg}package.json').name")
+            BODY="${BODY}\n- \`${NAME}@${VERSION}\`"
+          done
+
+          gh release create "${TAG}" \
+            --title "${TAG}" \
+            --notes "$(echo -e "${BODY}")" \
+            --latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish all packages to npm via changesets.
+# Then replace the per-package git tags with a single unified tag.
+
+# 1. Publish to npm (changesets creates per-package tags like @goodie-ts/core@0.3.0)
+pnpm changeset publish
+
+# 2. Read the unified version from core (all packages share the same version via "fixed")
+VERSION=$(node -p "require('./packages/core/package.json').version")
+UNIFIED_TAG="v${VERSION}"
+
+echo "Published version: ${VERSION}"
+echo "Creating unified tag: ${UNIFIED_TAG}"
+
+# 3. Delete per-package tags (local only — they haven't been pushed)
+git tag --list '@goodie-ts/*' | while read -r tag; do
+  echo "Deleting per-package tag: ${tag}"
+  git tag -d "${tag}"
+done
+
+# 4. Create a single unified tag
+git tag -a "${UNIFIED_TAG}" -m "Release ${UNIFIED_TAG}"
+
+# 5. Push the unified tag
+git push origin "${UNIFIED_TAG}"
+
+echo "Done — released ${UNIFIED_TAG}"


### PR DESCRIPTION
## Summary

- Replace N per-package git tags and GitHub releases with a single unified `v{version}` tag and release
- Add `fixed` versioning in changesets so all `@goodie-ts/*` packages always share the same version
- Add `scripts/publish.sh` that publishes to npm, deletes per-package tags, and creates a unified tag
- Update release workflow to create a single GitHub release after publish

**Before:** 6 tags (`@goodie-ts/core@0.2.0`, `@goodie-ts/decorators@0.2.0`, ...) and 6 GitHub releases per version bump.

**After:** 1 tag (`v0.3.0`) and 1 GitHub release listing all published packages.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [ ] Verify release workflow on next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)