### PR TITLE
refactor: @ConfigurationProperties reads from introspection metadata …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ pnpm clean          # Clean all dist/
 | Package | Purpose |
 |---------|---------|
 | `packages/core` | Runtime container, decorators, AOP runtime (interceptor chain, advice wrappers), BeanDefinition, InjectionToken, topoSort |
-| `packages/transformer` | ts-morph scanner → resolver → graph-builder → codegen, plugin system, built-in AOP + config plugins. Framework-agnostic — no HTTP knowledge. |
+| `packages/transformer` | ts-morph scanner → resolver → graph-builder → codegen, plugin system, built-in AOP + config + introspection plugins. Framework-agnostic — no HTTP knowledge. |
 | `packages/cli` | CLI tool — `goodie generate` with watch mode |
 | `packages/vite-plugin` | Vite integration, runs transformer on build/HMR |
 | `packages/testing` | TestContext with bean overrides and @MockDefinition |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ const userService = app.context.get(UserService);
 | Package | Description |
 |---------|-------------|
 | [`@goodie-ts/core`](./packages/core) | Runtime container, decorators, AOP interceptor chain, `ApplicationContext`, `InjectionToken`, topological sort |
-| [`@goodie-ts/transformer`](./packages/transformer) | ts-morph scanner, code generator, and built-in AOP + config plugins (build-time only) |
+| [`@goodie-ts/transformer`](./packages/transformer) | ts-morph scanner, code generator, and built-in AOP + config + introspection plugins (build-time only) |
 | [`@goodie-ts/cli`](./packages/cli) | CLI tool — `goodie generate` with watch mode |
 | [`@goodie-ts/vite-plugin`](./packages/vite-plugin) | Vite integration — runs transformer on build and HMR |
 | [`@goodie-ts/testing`](./packages/testing) | `TestContext` with bean overrides and `@MockDefinition` |

--- a/packages/transformer/CLAUDE.md
+++ b/packages/transformer/CLAUDE.md
@@ -32,7 +32,7 @@ When `configDir` is set, the transformer reads JSON config files at build time a
 | `src/aop-scanner.ts` | `scanAopDecoratorDefinitions()` — scans `createAopDecorator<{...}>()` calls, extracts config from type parameters via type checker |
 | `src/aop-plugin.ts` | `createDeclarativeAopPlugin()` — generic AOP plugin driven by `AopDecoratorDeclaration` mappings |
 | `src/builtin-aop-plugin.ts` | `createAopPlugin()` — built-in plugin scanning `@Around/@Before/@After` decorators |
-| `src/builtin-config-plugin.ts` | `createConfigPlugin()` — built-in plugin scanning `@ConfigurationProperties` |
+| `src/builtin-config-plugin.ts` | `createConfigPlugin()` — built-in plugin reading introspection metadata for `@ConfigurationProperties` |
 | `src/builtin-introspection-plugin.ts` | `createIntrospectionPlugin()` — built-in plugin scanning `@Introspected`, extracting field types and decorator metadata |
 | `src/library-beans.ts` | `serializeBeans()`, `deserializeBeans()`, `discoverLibraryBeans()`, `discoverAopMappings()` |
 | `src/discover-plugins.ts` | `discoverAll()` — single-pass plugin + library manifest discovery from `node_modules` |
@@ -67,13 +67,15 @@ External packages can contribute codegen via the `TransformerPlugin` interface:
 - `visitClass` / `visitMethod` — scan hooks called during the single AST pass
 - `codegen(beans, context?)` — receives `CodegenContext` with build-time config (`context.config` is a flattened `Record<string, string>` from JSON config files). Returns `CodegenContribution` (`{ imports, code }`) appended to generated output
 
-Plugins are auto-discovered via `"goodie": { "plugin": "dist/plugin.js" }` in package.json. Built-in plugins (AOP, config, conditional, introspection) are always active.
+Plugins are auto-discovered via `"goodie": { "plugin": "dist/plugin.js" }` in package.json. Built-in plugins (AOP, introspection, config, conditional) are always active — introspection runs before config since `@ConfigurationProperties` implies `@Introspected`.
 
 ## Introspection Plugin
 
-The built-in introspection plugin scans `@Introspected()` classes and generates `MetadataRegistry` registration code. Key points:
+The built-in introspection plugin scans `@Introspected()` and `@ConfigurationProperties()` classes and generates `MetadataRegistry` registration code. Key points:
 
 - **NOT beans** — `@Introspected` classes are value objects (DTOs, request/response types). The plugin does NOT call `ctx.registerBean()`.
+- **`@ConfigurationProperties` implies `@Introspected`** — config classes are automatically introspected. The config plugin reads field metadata from `ctx.metadata.introspectedFields` rather than doing its own AST scanning.
+- **Inter-plugin metadata sharing** — stores scanned fields in `ctx.metadata.introspectedFields` so downstream plugins (e.g. config) can consume the data without duplicating scanning logic.
 - **Field type resolution** — builds a recursive `FieldType` tree: primitive, literal, array, reference, union, optional, nullable. Handles `boolean` correctly (ts-morph represents it as `false | true` union).
 - **Generic decorator metadata** — records ALL field decorators as `DecoratorMeta { name, args }`. The plugin doesn't interpret decorators — downstream consumers (validation, OpenAPI) do.
 - **Codegen** — emits `MetadataRegistry` import, class imports, and `__metadataRegistry.register(...)` calls with serialized field metadata.

--- a/packages/transformer/__tests__/builtin-config-plugin.test.ts
+++ b/packages/transformer/__tests__/builtin-config-plugin.test.ts
@@ -2,6 +2,7 @@ import { transformInMemory } from '@goodie-ts/transformer';
 import { Project } from 'ts-morph';
 import { describe, expect, it, vi } from 'vitest';
 import { createConfigPlugin } from '../src/builtin-config-plugin.js';
+import { createIntrospectionPlugin } from '../src/builtin-introspection-plugin.js';
 
 const DECORATOR_STUBS = `
 export function Injectable() { return (t: any, c: any) => {} }
@@ -21,7 +22,10 @@ function createTestProject(
     project.createSourceFile(filePath, content);
   }
 
-  return transformInMemory(project, outputPath, [createConfigPlugin()]);
+  return transformInMemory(project, outputPath, [
+    createIntrospectionPlugin(),
+    createConfigPlugin(),
+  ]);
 }
 
 describe('Config Transformer Plugin', () => {
@@ -396,81 +400,22 @@ describe('Config Transformer Plugin', () => {
     warnSpy.mockRestore();
   });
 
-  it('should skip @Value-decorated properties to avoid duplicate valueFields entries', () => {
+  it('should generate introspection metadata for @ConfigurationProperties class', () => {
     const result = createTestProject({
       '/src/Config.ts': `
-        import { Singleton, ConfigurationProperties, Value } from './decorators.js'
+        import { Singleton, ConfigurationProperties } from './decorators.js'
 
         @Singleton()
         @ConfigurationProperties('app')
         export class Config {
           name = 'my-app'
-
-          @Value('APP_SECRET')
-          accessor secret!: string
+          port = 3000
         }
       `,
     });
 
-    const bean = result.beans.find(
-      (b) => b.tokenRef.kind === 'class' && b.tokenRef.className === 'Config',
-    );
-    expect(bean).toBeDefined();
-
-    const valueFields = bean!.metadata.valueFields as Array<{
-      fieldName: string;
-      key: string;
-      default?: string;
-    }>;
-
-    // 'secret' should appear only once (from the scanner's @Value handling),
-    // NOT duplicated by the config plugin with key 'app.secret'
-    const secretEntries = valueFields.filter((f) => f.fieldName === 'secret');
-    expect(secretEntries).toHaveLength(1);
-    expect(secretEntries[0].key).toBe('APP_SECRET');
-
-    // 'name' should still be present from the config plugin
-    const nameField = valueFields.find((f) => f.fieldName === 'name');
-    expect(nameField).toBeDefined();
-    expect(nameField!.key).toBe('app.name');
-  });
-
-  it('should merge @Value fields with @ConfigurationProperties fields on the same class', () => {
-    const result = createTestProject({
-      '/src/Config.ts': `
-        import { Singleton, ConfigurationProperties, Value } from './decorators.js'
-
-        @Singleton()
-        @ConfigurationProperties('app')
-        export class Config {
-          name = 'my-app'
-
-          @Value('APP_SECRET')
-          accessor secret!: string
-        }
-      `,
-    });
-
-    const bean = result.beans.find(
-      (b) => b.tokenRef.kind === 'class' && b.tokenRef.className === 'Config',
-    );
-    expect(bean).toBeDefined();
-
-    const valueFields = bean!.metadata.valueFields as Array<{
-      fieldName: string;
-      key: string;
-      default?: string;
-    }>;
-    expect(valueFields).toBeDefined();
-
-    // @Value field from the scanner
-    const secretField = valueFields.find((f) => f.fieldName === 'secret');
-    expect(secretField).toBeDefined();
-    expect(secretField!.key).toBe('APP_SECRET');
-
-    // @ConfigurationProperties field from the plugin
-    const nameField = valueFields.find((f) => f.fieldName === 'name');
-    expect(nameField).toBeDefined();
-    expect(nameField!.key).toBe('app.name');
+    // @ConfigurationProperties implies @Introspected — MetadataRegistry code should be generated
+    expect(result.code).toContain('MetadataRegistry');
+    expect(result.code).toContain("className: 'Config'");
   });
 });

--- a/packages/transformer/src/builtin-config-plugin.ts
+++ b/packages/transformer/src/builtin-config-plugin.ts
@@ -3,14 +3,14 @@ import type { ClassVisitorContext, TransformerPlugin } from './options.js';
 /**
  * Built-in config transformer plugin.
  *
- * Scans `@ConfigurationProperties(prefix)` on classes that also have
- * `@Singleton` (or `@Injectable`). For each public class field, generates a
- * `valueFields` metadata entry with key `prefix.fieldName` and the
+ * Reads field metadata from the introspection plugin (`ctx.metadata.introspectedFields`)
+ * for `@ConfigurationProperties(prefix)` classes. For each introspected field,
+ * generates a `valueFields` metadata entry with key `prefix.fieldName` and the
  * field initializer as the default value.
  *
- * Private and protected fields (by TypeScript modifier or underscore prefix)
- * are excluded. A warning is emitted if `@ConfigurationProperties` is used
- * without a companion `@Singleton` or `@Injectable` decorator.
+ * Requires the introspection plugin to run first — `@ConfigurationProperties`
+ * implies `@Introspected`. A warning is emitted if `@ConfigurationProperties`
+ * is used without a companion `@Singleton` or `@Injectable` decorator.
  *
  * The existing codegen automatically handles `valueFields` — it creates
  * the `__Goodie_Config` token, adds it as a dependency, and generates
@@ -73,28 +73,25 @@ export function createConfigPlugin(): TransformerPlugin {
       }
       const prefix = prefixArg.slice(1, -1);
 
-      // Extract class fields (both regular and accessor properties)
+      // Read fields from introspection metadata (populated by the introspection plugin)
+      const introspectedFields = ctx.metadata.introspectedFields as
+        | Array<{ name: string }>
+        | undefined;
+
+      if (!introspectedFields) return;
+
       const fields: Array<{
         fieldName: string;
         defaultValue: string | undefined;
       }> = [];
 
-      for (const prop of ctx.classDeclaration.getProperties()) {
-        const fieldName = prop.getName();
-
-        // Skip private/protected fields (by TypeScript modifier or convention)
-        const scope = prop.getScope();
-        if (scope === 'private' || scope === 'protected') continue;
-        if (fieldName.startsWith('_')) continue;
-
-        // Skip fields already decorated with @Value (handled by the scanner)
-        if (prop.getDecorators().some((d) => d.getName() === 'Value')) continue;
-
-        // Get default value from initializer
-        const initializer = prop.getInitializer();
+      for (const field of introspectedFields) {
+        // Look up initializer for default value
+        const prop = ctx.classDeclaration.getProperty(field.name);
+        const initializer = prop?.getInitializer();
         const defaultValue = initializer ? initializer.getText() : undefined;
 
-        fields.push({ fieldName, defaultValue });
+        fields.push({ fieldName: field.name, defaultValue });
       }
 
       if (fields.length === 0) return;

--- a/packages/transformer/src/builtin-introspection-plugin.ts
+++ b/packages/transformer/src/builtin-introspection-plugin.ts
@@ -60,12 +60,16 @@ export function createIntrospectionPlugin(): TransformerPlugin {
 
     visitClass(ctx: ClassVisitorContext): void {
       const isIntrospected = ctx.decorators.some(
-        (d) => d.name === 'Introspected',
+        (d) =>
+          d.name === 'Introspected' || d.name === 'ConfigurationProperties',
       );
       if (!isIntrospected) return;
 
       const cls = ctx.classDeclaration;
       const fields = scanClassFields(cls);
+
+      // Store in metadata so other plugins (e.g. config) can consume it
+      ctx.metadata.introspectedFields = fields;
 
       introspectedClasses.push({
         className: ctx.className,
@@ -125,9 +129,10 @@ function scanClassFields(cls: ClassDeclaration): ScannedIntrospectedField[] {
   for (const prop of cls.getProperties()) {
     const name = String(prop.getName());
 
-    // Skip private/protected
+    // Skip private/protected (by TypeScript modifier or underscore convention)
     const scope = prop.getScope();
     if (scope === 'private' || scope === 'protected') continue;
+    if (name.startsWith('_')) continue;
 
     // Resolve type
     const propType = prop.getType();

--- a/packages/transformer/src/transform.ts
+++ b/packages/transformer/src/transform.ts
@@ -127,9 +127,9 @@ export async function transform(
   // Built-in plugins always active; declarative AOP comes next; then discovered + user plugins
   const builtinPlugins = [
     createAopPlugin(),
+    createIntrospectionPlugin(),
     createConfigPlugin(),
     createConditionalPlugin(),
-    createIntrospectionPlugin(),
   ];
   const activePlugins = mergePlugins(
     [...builtinPlugins, ...aopPlugins, ...discoveredPlugins],
@@ -301,9 +301,9 @@ export function transformInMemory(
       : [];
   const builtinPlugins = [
     createAopPlugin(),
+    createIntrospectionPlugin(),
     createConfigPlugin(),
     createConditionalPlugin(),
-    createIntrospectionPlugin(),
   ];
   const activePlugins = mergePlugins(
     [...builtinPlugins, ...aopPlugins],
@@ -441,9 +441,9 @@ export async function transformLibrary(
 
   const builtinPlugins = [
     createAopPlugin(),
+    createIntrospectionPlugin(),
     createConfigPlugin(),
     createConditionalPlugin(),
-    createIntrospectionPlugin(),
   ];
   const activePlugins = mergePlugins(
     [...builtinPlugins, ...aopPlugins, ...discovered],


### PR DESCRIPTION
@ConfigurationProperties now implies @Introspected — the config plugin reads field metadata from ctx.metadata.introspectedFields instead of doing ad-hoc AST scanning. Built-in plugin order: introspection runs before config. @Value and @ConfigurationProperties are mutually exclusive.

## Summary

<!-- What does this PR do? -->

## Test plan

<!-- How was this tested? -->

- [X] `pnpm lint` passes
- [X] `pnpm build` passes
- [X] `pnpm test` passes
