### PR TITLE
feat: @goodie-ts/openapi — OpenAPI 3.1 spec from introspection metadata

### DIFF
--- a/packages/core/src/application-context.ts
+++ b/packages/core/src/application-context.ts
@@ -44,7 +44,7 @@ export class ApplicationContext {
   private closed = false;
   private startupMetrics: StartupMetrics | undefined;
 
-  private constructor(private readonly sortedDefs: BeanDefinition[]) {
+  constructor(private readonly sortedDefs: BeanDefinition[]) {
     for (const def of sortedDefs) {
       const existing = this.defsByToken.get(def.token);
       if (existing) {
@@ -104,20 +104,17 @@ export class ApplicationContext {
     ctx.startupMetrics = metrics;
 
     // Self-register so beans can inject ApplicationContext.
-    // Cast needed because ApplicationContext has a private constructor,
-    // making typeof ApplicationContext incompatible with Constructor<T>.
-    const selfToken = ApplicationContext as unknown as Token;
-    ctx.singletonCache.set(selfToken, ctx);
+    ctx.singletonCache.set(ApplicationContext, ctx);
     const selfDef: BeanDefinition = {
-      token: selfToken as Constructor,
+      token: ApplicationContext,
       scope: 'singleton',
       dependencies: [],
       factory: () => ctx,
       eager: false,
       metadata: {},
     };
-    ctx.defsByToken.set(selfToken, [selfDef]);
-    ctx.primaryDef.set(selfToken, selfDef);
+    ctx.defsByToken.set(ApplicationContext, [selfDef]);
+    ctx.primaryDef.set(ApplicationContext, selfDef);
 
     if (metrics) {
       metrics.timeStageSync('validateDependencies', () =>
@@ -278,7 +275,7 @@ export class ApplicationContext {
    * including the self-registered ApplicationContext definition.
    */
   getDefinitions(): readonly BeanDefinition[] {
-    const selfDef = this.primaryDef.get(ApplicationContext as unknown as Token);
+    const selfDef = this.primaryDef.get(ApplicationContext);
     return selfDef ? [selfDef, ...this.sortedDefs] : [...this.sortedDefs];
   }
 

--- a/packages/http/__tests__/http-plugin.test.ts
+++ b/packages/http/__tests__/http-plugin.test.ts
@@ -108,6 +108,7 @@ describe('HTTP Plugin', () => {
       status: 200,
       returnType: 'void',
       params: [],
+      decorators: [],
     });
     expect(httpController.routes[1]).toEqual({
       methodName: 'create',
@@ -116,6 +117,7 @@ describe('HTTP Plugin', () => {
       status: 200,
       returnType: 'void',
       params: [],
+      decorators: [],
     });
     expect(httpController.routes[2]).toEqual({
       methodName: 'update',
@@ -124,6 +126,7 @@ describe('HTTP Plugin', () => {
       status: 200,
       returnType: 'void',
       params: [],
+      decorators: [],
     });
     expect(httpController.routes[3]).toEqual({
       methodName: 'remove',
@@ -132,6 +135,7 @@ describe('HTTP Plugin', () => {
       status: 200,
       returnType: 'void',
       params: [],
+      decorators: [],
     });
     expect(httpController.routes[4]).toEqual({
       methodName: 'patch',
@@ -140,6 +144,7 @@ describe('HTTP Plugin', () => {
       status: 200,
       returnType: 'void',
       params: [],
+      decorators: [],
     });
   });
 

--- a/packages/http/src/plugin.ts
+++ b/packages/http/src/plugin.ts
@@ -3,7 +3,10 @@ import type {
   MethodVisitorContext,
   TransformerPlugin,
 } from '@goodie-ts/transformer';
-import { InvalidDecoratorUsageError } from '@goodie-ts/transformer';
+import {
+  extractDecoratorMeta,
+  InvalidDecoratorUsageError,
+} from '@goodie-ts/transformer';
 import type { MethodDeclaration, Type } from 'ts-morph';
 
 import type {
@@ -27,6 +30,13 @@ const BODY_METHODS = new Set<HttpMethod>(['post', 'put', 'patch']);
 
 /** Primitive types that map to query parameters. */
 const PRIMITIVE_TYPES = new Set(['string', 'number', 'boolean']);
+
+/** Decorators handled by the HTTP plugin or framework — not captured as generic metadata. */
+const IGNORED_METHOD_DECORATORS = new Set([
+  ...Object.keys(ROUTE_DECORATOR_MAP),
+  'Status',
+  'Validated',
+]);
 
 /**
  * HTTP scan-phase transformer plugin.
@@ -216,6 +226,12 @@ export default function createHttpPlugin(): TransformerPlugin {
 
       const returnType = extractReturnType(methodDeclaration);
 
+      // Capture all non-route decorators as generic metadata
+      const methodDecorators = extractDecoratorMeta(
+        decorators,
+        IGNORED_METHOD_DECORATORS,
+      );
+
       const route: RouteMetadata = {
         methodName,
         httpMethod,
@@ -223,6 +239,7 @@ export default function createHttpPlugin(): TransformerPlugin {
         status,
         params,
         returnType,
+        decorators: methodDecorators,
       };
 
       controller.routes.push(route);

--- a/packages/http/src/route-metadata.ts
+++ b/packages/http/src/route-metadata.ts
@@ -1,3 +1,5 @@
+import type { DecoratorMeta } from '@goodie-ts/core';
+
 /** HTTP method for a route. */
 export type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
 
@@ -27,6 +29,8 @@ export interface RouteMetadata {
   params: ParamMetadata[];
   /** Return type text with Promise<T> and Response<T> unwrapped (e.g. 'Todo', 'Todo | null', 'void'). */
   returnType: string;
+  /** All non-route decorators on this method (e.g. @ApiResponse, @ApiOperation). Empty if none. */
+  decorators?: DecoratorMeta[];
 }
 
 /** Controller metadata stored on bean metadata by the http plugin. */

--- a/packages/management/__tests__/env-endpoint.test.ts
+++ b/packages/management/__tests__/env-endpoint.test.ts
@@ -136,8 +136,8 @@ describe('EnvEndpoint', () => {
     const result = endpoint.env();
 
     const body = result.body as { properties: Record<string, unknown> };
-    expect(body.properties['DB_PASSWORD']).toBe('******');
-    expect(body.properties['JWT_SECRET']).toBe('******');
+    expect(body.properties.DB_PASSWORD).toBe('******');
+    expect(body.properties.JWT_SECRET).toBe('******');
   });
 
   it('does not mask keys that only contain patterns as substrings', () => {

--- a/packages/management/src/beans-endpoint.ts
+++ b/packages/management/src/beans-endpoint.ts
@@ -20,7 +20,7 @@ export class BeansEndpoint {
       .getDefinitions()
       .filter((def) =>
         typeof def.token === 'function'
-          ? (def.token as Function) !== ApplicationContext
+          ? def.token !== ApplicationContext
           : def.token.description !== '__Goodie_Config',
       );
 

--- a/packages/management/src/beans-endpoint.ts
+++ b/packages/management/src/beans-endpoint.ts
@@ -20,7 +20,7 @@ export class BeansEndpoint {
       .getDefinitions()
       .filter((def) =>
         typeof def.token === 'function'
-          ? def.token !== ApplicationContext
+          ? (def.token as Function) !== ApplicationContext
           : def.token.description !== '__Goodie_Config',
       );
 

--- a/packages/openapi/__tests__/openapi-controller.test.ts
+++ b/packages/openapi/__tests__/openapi-controller.test.ts
@@ -1,0 +1,24 @@
+import { Response } from '@goodie-ts/http';
+import { describe, expect, it, vi } from 'vitest';
+import { OpenApiController } from '../src/openapi-controller.js';
+import type { OpenApiSpecBuilder } from '../src/openapi-spec-builder.js';
+
+describe('OpenApiController', () => {
+  it('returns the cached spec as a 200 JSON response', () => {
+    const mockSpec = {
+      openapi: '3.1.0',
+      info: { title: 'Test', version: '1.0.0' },
+    };
+    const mockBuilder = {
+      getSpec: vi.fn().mockReturnValue(mockSpec),
+    } as unknown as OpenApiSpecBuilder;
+
+    const controller = new OpenApiController(mockBuilder);
+    const result = controller.spec();
+
+    expect(result).toBeInstanceOf(Response);
+    expect(result.status).toBe(200);
+    expect(result.body).toBe(mockSpec);
+    expect(mockBuilder.getSpec).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/openapi/__tests__/openapi-spec-builder.test.ts
+++ b/packages/openapi/__tests__/openapi-spec-builder.test.ts
@@ -27,17 +27,22 @@ function createMockConfig(
 
 function createMockContext(
   controllers: Array<{
+    name: string;
     metadata: ControllerMetadata;
   }>,
 ): ApplicationContext {
-  const definitions = controllers.map((ctrl) => ({
-    token: class {},
-    scope: 'singleton' as const,
-    dependencies: [],
-    factory: () => null,
-    eager: false,
-    metadata: { httpController: ctrl.metadata },
-  })) as BeanDefinition[];
+  const definitions = controllers.map((ctrl) => {
+    // Create a named class so discoverControllers() can extract the name
+    const NamedClass = { [ctrl.name]: class {} }[ctrl.name];
+    return {
+      token: NamedClass,
+      scope: 'singleton' as const,
+      dependencies: [],
+      factory: () => null,
+      eager: false,
+      metadata: { httpController: ctrl.metadata },
+    };
+  }) as BeanDefinition[];
 
   return {
     getDefinitions: vi.fn().mockReturnValue(definitions),
@@ -79,6 +84,7 @@ describe('OpenApiSpecBuilder', () => {
   it('generates paths from controller routes', () => {
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api/todos',
           routes: [
@@ -100,12 +106,15 @@ describe('OpenApiSpecBuilder', () => {
 
     expect(spec.paths['/api/todos']).toBeDefined();
     expect(spec.paths['/api/todos'].get).toBeDefined();
-    expect(spec.paths['/api/todos'].get.operationId).toBe('list');
+    expect(spec.paths['/api/todos'].get.operationId).toBe(
+      'TodoController_list',
+    );
   });
 
   it('converts :param to {param} in paths', () => {
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api/todos',
           routes: [
@@ -141,6 +150,7 @@ describe('OpenApiSpecBuilder', () => {
   it('includes query parameters', () => {
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api/todos',
           routes: [
@@ -204,6 +214,7 @@ describe('OpenApiSpecBuilder', () => {
 
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api/todos',
           routes: [
@@ -274,6 +285,7 @@ describe('OpenApiSpecBuilder', () => {
 
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api/todos',
           routes: [
@@ -320,6 +332,7 @@ describe('OpenApiSpecBuilder', () => {
 
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api/todos',
           routes: [
@@ -357,6 +370,7 @@ describe('OpenApiSpecBuilder', () => {
 
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api/todos',
           routes: [
@@ -388,8 +402,7 @@ describe('OpenApiSpecBuilder', () => {
         'application/json'
       ].schema,
     ).toEqual({
-      $ref: '#/components/schemas/Todo',
-      nullable: true,
+      oneOf: [{ $ref: '#/components/schemas/Todo' }, { type: 'null' }],
     });
   });
 
@@ -437,6 +450,7 @@ describe('OpenApiSpecBuilder', () => {
 
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api',
           routes: [
@@ -485,8 +499,8 @@ describe('OpenApiSpecBuilder', () => {
     expect(schema.properties.tags).toEqual({
       type: 'array',
       items: { type: 'string' },
-      minLength: 1,
-      maxLength: 5,
+      minItems: 1,
+      maxItems: 5,
     });
   });
 
@@ -526,6 +540,7 @@ describe('OpenApiSpecBuilder', () => {
 
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api',
           routes: [
@@ -604,6 +619,7 @@ describe('OpenApiSpecBuilder', () => {
 
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api',
           routes: [
@@ -665,6 +681,7 @@ describe('OpenApiSpecBuilder', () => {
 
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api',
           routes: [
@@ -716,6 +733,7 @@ describe('OpenApiSpecBuilder', () => {
   it('handles void return type with no response body', () => {
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api/todos',
           routes: [
@@ -750,6 +768,7 @@ describe('OpenApiSpecBuilder', () => {
   it('uses custom status code from route metadata', () => {
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api/todos',
           routes: [
@@ -776,6 +795,7 @@ describe('OpenApiSpecBuilder', () => {
   it('merges multiple routes on the same path', () => {
     const ctx = createMockContext([
       {
+        name: 'TodoController',
         metadata: {
           basePath: '/api/todos',
           routes: [

--- a/packages/openapi/__tests__/openapi-spec-builder.test.ts
+++ b/packages/openapi/__tests__/openapi-spec-builder.test.ts
@@ -1,0 +1,809 @@
+import type {
+  ApplicationContext,
+  BeanDefinition,
+  TypeMetadata,
+} from '@goodie-ts/core';
+import { MetadataRegistry } from '@goodie-ts/core';
+import type { ControllerMetadata } from '@goodie-ts/http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OpenApiConfig } from '../src/openapi-config.js';
+import { OpenApiSpecBuilder } from '../src/openapi-spec-builder.js';
+
+// ── Helpers ──
+
+class CreateTodoDto {}
+class UpdateTodoDto {}
+class Todo {}
+
+function createMockConfig(
+  overrides: Partial<OpenApiConfig> = {},
+): OpenApiConfig {
+  const config = new OpenApiConfig();
+  config.title = overrides.title ?? 'Test API';
+  config.version = overrides.version ?? '1.0.0';
+  config.description = overrides.description ?? '';
+  return config;
+}
+
+function createMockContext(
+  controllers: Array<{
+    metadata: ControllerMetadata;
+  }>,
+): ApplicationContext {
+  const definitions = controllers.map((ctrl) => ({
+    token: class {},
+    scope: 'singleton' as const,
+    dependencies: [],
+    factory: () => null,
+    eager: false,
+    metadata: { httpController: ctrl.metadata },
+  })) as BeanDefinition[];
+
+  return {
+    getDefinitions: vi.fn().mockReturnValue(definitions),
+  } as unknown as ApplicationContext;
+}
+
+function registerType(metadata: TypeMetadata): void {
+  MetadataRegistry.INSTANCE.register(metadata);
+}
+
+// ── Tests ──
+
+describe('OpenApiSpecBuilder', () => {
+  beforeEach(() => {
+    MetadataRegistry.INSTANCE.reset();
+  });
+
+  afterEach(() => {
+    MetadataRegistry.INSTANCE.reset();
+  });
+
+  it('generates basic spec with info from config', () => {
+    const ctx = createMockContext([]);
+    const config = createMockConfig({
+      title: 'My API',
+      version: '2.0.0',
+      description: 'A test API',
+    });
+
+    const builder = new OpenApiSpecBuilder(ctx, config);
+    const spec = builder.getSpec() as any;
+
+    expect(spec.openapi).toBe('3.1.0');
+    expect(spec.info.title).toBe('My API');
+    expect(spec.info.version).toBe('2.0.0');
+    expect(spec.info.description).toBe('A test API');
+  });
+
+  it('generates paths from controller routes', () => {
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'list',
+              httpMethod: 'get',
+              path: '/',
+              status: 200,
+              params: [],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    expect(spec.paths['/api/todos']).toBeDefined();
+    expect(spec.paths['/api/todos'].get).toBeDefined();
+    expect(spec.paths['/api/todos'].get.operationId).toBe('list');
+  });
+
+  it('converts :param to {param} in paths', () => {
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'getById',
+              httpMethod: 'get',
+              path: '/:id',
+              status: 200,
+              params: [
+                {
+                  name: 'id',
+                  binding: 'path',
+                  typeName: 'string',
+                  optional: false,
+                },
+              ],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    expect(spec.paths['/api/todos/{id}']).toBeDefined();
+    expect(spec.paths['/api/todos/{id}'].get.parameters).toEqual([
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ]);
+  });
+
+  it('includes query parameters', () => {
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'list',
+              httpMethod: 'get',
+              path: '/',
+              status: 200,
+              params: [
+                {
+                  name: 'completed',
+                  binding: 'query',
+                  typeName: 'boolean',
+                  optional: true,
+                },
+                {
+                  name: 'limit',
+                  binding: 'query',
+                  typeName: 'number',
+                  optional: true,
+                },
+              ],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    expect(spec.paths['/api/todos'].get.parameters).toEqual([
+      {
+        name: 'completed',
+        in: 'query',
+        required: false,
+        schema: { type: 'boolean' },
+      },
+      {
+        name: 'limit',
+        in: 'query',
+        required: false,
+        schema: { type: 'number' },
+      },
+    ]);
+  });
+
+  it('generates request body from @Introspected body param', () => {
+    registerType({
+      type: CreateTodoDto,
+      className: 'CreateTodoDto',
+      fields: [
+        {
+          name: 'title',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [],
+        },
+      ],
+    });
+
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'create',
+              httpMethod: 'post',
+              path: '/',
+              status: 201,
+              params: [
+                {
+                  name: 'body',
+                  binding: 'body',
+                  typeName: 'CreateTodoDto',
+                  optional: false,
+                },
+              ],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    const op = spec.paths['/api/todos'].post;
+    expect(op.requestBody).toEqual({
+      required: true,
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/CreateTodoDto' },
+        },
+      },
+    });
+
+    expect(spec.components.schemas.CreateTodoDto).toEqual({
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+      },
+      required: ['title'],
+    });
+  });
+
+  it('generates response schema from return type', () => {
+    registerType({
+      type: Todo,
+      className: 'Todo',
+      fields: [
+        {
+          name: 'id',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [],
+        },
+        {
+          name: 'title',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [],
+        },
+        {
+          name: 'completed',
+          type: { kind: 'primitive', type: 'boolean' },
+          decorators: [],
+        },
+      ],
+    });
+
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'getById',
+              httpMethod: 'get',
+              path: '/:id',
+              status: 200,
+              params: [
+                {
+                  name: 'id',
+                  binding: 'path',
+                  typeName: 'string',
+                  optional: false,
+                },
+              ],
+              returnType: 'Todo',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    const response = spec.paths['/api/todos/{id}'].get.responses['200'];
+    expect(response.content['application/json'].schema).toEqual({
+      $ref: '#/components/schemas/Todo',
+    });
+
+    expect(spec.components.schemas.Todo).toBeDefined();
+    expect(spec.components.schemas.Todo.properties.id).toEqual({
+      type: 'string',
+    });
+  });
+
+  it('handles array return types', () => {
+    registerType({
+      type: Todo,
+      className: 'Todo',
+      fields: [],
+    });
+
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'list',
+              httpMethod: 'get',
+              path: '/',
+              status: 200,
+              params: [],
+              returnType: 'Todo[]',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    expect(
+      spec.paths['/api/todos'].get.responses['200'].content['application/json']
+        .schema,
+    ).toEqual({
+      type: 'array',
+      items: { $ref: '#/components/schemas/Todo' },
+    });
+  });
+
+  it('handles nullable return types', () => {
+    registerType({
+      type: Todo,
+      className: 'Todo',
+      fields: [],
+    });
+
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'getById',
+              httpMethod: 'get',
+              path: '/:id',
+              status: 200,
+              params: [
+                {
+                  name: 'id',
+                  binding: 'path',
+                  typeName: 'string',
+                  optional: false,
+                },
+              ],
+              returnType: 'Todo | null',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    expect(
+      spec.paths['/api/todos/{id}'].get.responses['200'].content[
+        'application/json'
+      ].schema,
+    ).toEqual({
+      $ref: '#/components/schemas/Todo',
+      nullable: true,
+    });
+  });
+
+  it('maps constraint decorators to schema properties', () => {
+    registerType({
+      type: CreateTodoDto,
+      className: 'CreateTodoDto',
+      fields: [
+        {
+          name: 'title',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [
+            { name: 'NotBlank', args: {} },
+            { name: 'MaxLength', args: { value: 255 } },
+          ],
+        },
+        {
+          name: 'priority',
+          type: { kind: 'primitive', type: 'number' },
+          decorators: [
+            { name: 'Min', args: { value: 1 } },
+            { name: 'Max', args: { value: 10 } },
+          ],
+        },
+        {
+          name: 'email',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [{ name: 'Email', args: {} }],
+        },
+        {
+          name: 'slug',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [{ name: 'Pattern', args: { value: '^[a-z0-9-]+$' } }],
+        },
+        {
+          name: 'tags',
+          type: {
+            kind: 'array',
+            elementType: { kind: 'primitive', type: 'string' },
+          },
+          decorators: [{ name: 'Size', args: { value: 1, value2: 5 } }],
+        },
+      ],
+    });
+
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api',
+          routes: [
+            {
+              methodName: 'create',
+              httpMethod: 'post',
+              path: '/',
+              status: 201,
+              params: [
+                {
+                  name: 'body',
+                  binding: 'body',
+                  typeName: 'CreateTodoDto',
+                  optional: false,
+                },
+              ],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    const schema = spec.components.schemas.CreateTodoDto;
+    expect(schema.properties.title).toEqual({
+      type: 'string',
+      minLength: 1,
+      maxLength: 255,
+    });
+    expect(schema.properties.priority).toEqual({
+      type: 'number',
+      minimum: 1,
+      maximum: 10,
+    });
+    expect(schema.properties.email).toEqual({
+      type: 'string',
+      format: 'email',
+    });
+    expect(schema.properties.slug).toEqual({
+      type: 'string',
+      pattern: '^[a-z0-9-]+$',
+    });
+    expect(schema.properties.tags).toEqual({
+      type: 'array',
+      items: { type: 'string' },
+      minLength: 1,
+      maxLength: 5,
+    });
+  });
+
+  it('applies @Schema decorator metadata', () => {
+    registerType({
+      type: CreateTodoDto,
+      className: 'CreateTodoDto',
+      fields: [
+        {
+          name: 'title',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [
+            {
+              name: 'Schema',
+              args: {
+                description: 'The title of the todo',
+                example: 'Buy milk',
+              },
+            },
+          ],
+        },
+        {
+          name: 'status',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [
+            {
+              name: 'Schema',
+              args: {
+                enum: ['active', 'completed'],
+                deprecated: true,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api',
+          routes: [
+            {
+              methodName: 'create',
+              httpMethod: 'post',
+              path: '/',
+              status: 201,
+              params: [
+                {
+                  name: 'body',
+                  binding: 'body',
+                  typeName: 'CreateTodoDto',
+                  optional: false,
+                },
+              ],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    const schema = spec.components.schemas.CreateTodoDto;
+    expect(schema.properties.title).toEqual({
+      type: 'string',
+      description: 'The title of the todo',
+      example: 'Buy milk',
+    });
+    expect(schema.properties.status).toEqual({
+      type: 'string',
+      enum: ['active', 'completed'],
+      deprecated: true,
+    });
+  });
+
+  it('handles nested @Introspected references', () => {
+    class Address {}
+
+    registerType({
+      type: Address,
+      className: 'Address',
+      fields: [
+        {
+          name: 'street',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [],
+        },
+        {
+          name: 'city',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [],
+        },
+      ],
+    });
+
+    registerType({
+      type: CreateTodoDto,
+      className: 'CreateTodoDto',
+      fields: [
+        {
+          name: 'title',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [],
+        },
+        {
+          name: 'address',
+          type: { kind: 'reference', className: 'Address' },
+          decorators: [],
+        },
+      ],
+    });
+
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api',
+          routes: [
+            {
+              methodName: 'create',
+              httpMethod: 'post',
+              path: '/',
+              status: 201,
+              params: [
+                {
+                  name: 'body',
+                  binding: 'body',
+                  typeName: 'CreateTodoDto',
+                  optional: false,
+                },
+              ],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    expect(spec.components.schemas.CreateTodoDto.properties.address).toEqual({
+      $ref: '#/components/schemas/Address',
+    });
+    expect(spec.components.schemas.Address).toBeDefined();
+    expect(spec.components.schemas.Address.properties.street).toEqual({
+      type: 'string',
+    });
+  });
+
+  it('marks optional fields as not required', () => {
+    registerType({
+      type: UpdateTodoDto,
+      className: 'UpdateTodoDto',
+      fields: [
+        {
+          name: 'title',
+          type: {
+            kind: 'optional',
+            inner: { kind: 'primitive', type: 'string' },
+          },
+          decorators: [],
+        },
+        {
+          name: 'completed',
+          type: {
+            kind: 'optional',
+            inner: { kind: 'primitive', type: 'boolean' },
+          },
+          decorators: [],
+        },
+      ],
+    });
+
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api',
+          routes: [
+            {
+              methodName: 'update',
+              httpMethod: 'patch',
+              path: '/:id',
+              status: 200,
+              params: [
+                {
+                  name: 'id',
+                  binding: 'path',
+                  typeName: 'string',
+                  optional: false,
+                },
+                {
+                  name: 'body',
+                  binding: 'body',
+                  typeName: 'UpdateTodoDto',
+                  optional: false,
+                },
+              ],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    const schema = spec.components.schemas.UpdateTodoDto;
+    expect(schema.required).toBeUndefined();
+    expect(schema.properties.title).toEqual({ type: 'string' });
+    expect(schema.properties.completed).toEqual({ type: 'boolean' });
+  });
+
+  it('caches the spec on subsequent calls', () => {
+    const ctx = createMockContext([]);
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+
+    const spec1 = builder.getSpec();
+    const spec2 = builder.getSpec();
+
+    expect(spec1).toBe(spec2);
+  });
+
+  it('handles void return type with no response body', () => {
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'delete',
+              httpMethod: 'delete',
+              path: '/:id',
+              status: 204,
+              params: [
+                {
+                  name: 'id',
+                  binding: 'path',
+                  typeName: 'string',
+                  optional: false,
+                },
+              ],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    const response = spec.paths['/api/todos/{id}'].delete.responses['204'];
+    expect(response.description).toBe('');
+    expect(response.content).toBeUndefined();
+  });
+
+  it('uses custom status code from route metadata', () => {
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'create',
+              httpMethod: 'post',
+              path: '/',
+              status: 201,
+              params: [],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    expect(spec.paths['/api/todos'].post.responses['201']).toBeDefined();
+    expect(spec.paths['/api/todos'].post.responses['200']).toBeUndefined();
+  });
+
+  it('merges multiple routes on the same path', () => {
+    const ctx = createMockContext([
+      {
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'list',
+              httpMethod: 'get',
+              path: '/',
+              status: 200,
+              params: [],
+              returnType: 'void',
+            },
+            {
+              methodName: 'create',
+              httpMethod: 'post',
+              path: '/',
+              status: 201,
+              params: [],
+              returnType: 'void',
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    expect(spec.paths['/api/todos'].get).toBeDefined();
+    expect(spec.paths['/api/todos'].post).toBeDefined();
+  });
+});

--- a/packages/openapi/__tests__/openapi-spec-builder.test.ts
+++ b/packages/openapi/__tests__/openapi-spec-builder.test.ts
@@ -826,4 +826,178 @@ describe('OpenApiSpecBuilder', () => {
     expect(spec.paths['/api/todos'].get).toBeDefined();
     expect(spec.paths['/api/todos'].post).toBeDefined();
   });
+
+  it('applies @ApiOperation metadata to the operation', () => {
+    const ctx = createMockContext([
+      {
+        name: 'TodoController',
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'list',
+              httpMethod: 'get',
+              path: '/',
+              status: 200,
+              params: [],
+              returnType: 'void',
+              decorators: [
+                {
+                  name: 'ApiOperation',
+                  args: {
+                    summary: 'List all todos',
+                    description: 'Returns all todo items',
+                    tags: ['todos'],
+                    deprecated: false,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    const op = spec.paths['/api/todos'].get;
+    expect(op.summary).toBe('List all todos');
+    expect(op.description).toBe('Returns all todo items');
+    expect(op.tags).toEqual(['todos']);
+    expect(op.deprecated).toBe(false);
+  });
+
+  it('applies @ApiResponse decorators to add response entries', () => {
+    registerType({
+      type: Todo,
+      className: 'Todo',
+      fields: [],
+    });
+
+    const ctx = createMockContext([
+      {
+        name: 'TodoController',
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'getById',
+              httpMethod: 'get',
+              path: '/:id',
+              status: 200,
+              params: [
+                {
+                  name: 'id',
+                  binding: 'path',
+                  typeName: 'string',
+                  optional: false,
+                },
+              ],
+              returnType: 'Todo',
+              decorators: [
+                {
+                  name: 'ApiResponse',
+                  args: {
+                    value: 200,
+                    value2: { description: 'The todo item' },
+                  },
+                },
+                {
+                  name: 'ApiResponse',
+                  args: {
+                    value: 404,
+                    value2: { description: 'Todo not found' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    const responses = spec.paths['/api/todos/{id}'].get.responses;
+    expect(responses['200'].description).toBe('The todo item');
+    expect(responses['200'].content['application/json'].schema).toEqual({
+      $ref: '#/components/schemas/Todo',
+    });
+    expect(responses['404']).toEqual({ description: 'Todo not found' });
+  });
+
+  it('applies @ApiResponse with type override', () => {
+    registerType({
+      type: Todo,
+      className: 'Todo',
+      fields: [],
+    });
+
+    class ErrorResponse {}
+    registerType({
+      type: ErrorResponse,
+      className: 'ErrorResponse',
+      fields: [
+        {
+          name: 'message',
+          type: { kind: 'primitive', type: 'string' },
+          decorators: [],
+        },
+      ],
+    });
+
+    const ctx = createMockContext([
+      {
+        name: 'TodoController',
+        metadata: {
+          basePath: '/api/todos',
+          routes: [
+            {
+              methodName: 'getById',
+              httpMethod: 'get',
+              path: '/:id',
+              status: 200,
+              params: [
+                {
+                  name: 'id',
+                  binding: 'path',
+                  typeName: 'string',
+                  optional: false,
+                },
+              ],
+              returnType: 'Todo',
+              decorators: [
+                {
+                  name: 'ApiResponse',
+                  args: {
+                    value: 500,
+                    value2: {
+                      description: 'Internal server error',
+                      type: 'ErrorResponse',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const builder = new OpenApiSpecBuilder(ctx, createMockConfig());
+    const spec = builder.getSpec() as any;
+
+    const responses = spec.paths['/api/todos/{id}'].get.responses;
+    expect(responses['500']).toEqual({
+      description: 'Internal server error',
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/ErrorResponse' },
+        },
+      },
+    });
+    expect(spec.components.schemas.ErrorResponse).toBeDefined();
+  });
 });

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@goodie-ts/openapi",
+  "version": "1.0.0",
+  "description": "OpenAPI 3.1 spec generation from introspection metadata for goodie-ts",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GOOD-Code-ApS/goodie.git",
+    "directory": "packages/openapi"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "goodie": {
+    "beans": "dist/beans.json"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc && goodie generate --mode library",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@goodie-ts/core": ">=1.0.0",
+    "@goodie-ts/http": ">=1.0.0",
+    "openapi3-ts": ">=4.0.0"
+  },
+  "devDependencies": {
+    "@goodie-ts/core": "workspace:*",
+    "@goodie-ts/http": "workspace:*",
+    "@goodie-ts/cli": "workspace:*",
+    "@goodie-ts/transformer": "workspace:*",
+    "@types/node": "^22.0.0",
+    "openapi3-ts": "^4.4.0",
+    "ts-morph": "^24.0.0"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/openapi/src/decorators/api-operation.ts
+++ b/packages/openapi/src/decorators/api-operation.ts
@@ -1,0 +1,36 @@
+/**
+ * `@ApiOperation` decorator for documenting OpenAPI operation metadata on controller methods.
+ *
+ * No-op at runtime — the HTTP plugin captures it at build time as
+ * `DecoratorMeta { name: 'ApiOperation', args: { ... } }`.
+ * `OpenApiSpecBuilder` reads the metadata to enrich the operation object.
+ *
+ * @example
+ * ```typescript
+ * @Controller('/api/todos')
+ * class TodoController {
+ *   @Get('/')
+ *   @ApiOperation({ summary: 'List all todos', tags: ['todos'] })
+ *   list(): Todo[] { ... }
+ * }
+ * ```
+ */
+
+import type { MethodDec } from './types.js';
+
+export interface ApiOperationOptions {
+  /** Short summary of the operation. */
+  summary?: string;
+  /** Detailed description of the operation. */
+  description?: string;
+  /** Tags for grouping operations. */
+  tags?: string[];
+  /** Mark the operation as deprecated. */
+  deprecated?: boolean;
+}
+
+export function ApiOperation(_options: ApiOperationOptions): MethodDec {
+  return (_target, _context) => {
+    // No-op: metadata extracted at compile time by HTTP plugin
+  };
+}

--- a/packages/openapi/src/decorators/api-response.ts
+++ b/packages/openapi/src/decorators/api-response.ts
@@ -1,0 +1,38 @@
+/**
+ * `@ApiResponse` decorator for documenting HTTP response codes on controller methods.
+ *
+ * No-op at runtime — the HTTP plugin captures it at build time as
+ * `DecoratorMeta { name: 'ApiResponse', args: { value: status, value2: { ... } } }`.
+ * `OpenApiSpecBuilder` reads the metadata to generate response entries.
+ *
+ * Can be applied multiple times to document multiple response codes.
+ *
+ * @example
+ * ```typescript
+ * @Controller('/api/todos')
+ * class TodoController {
+ *   @Get('/:id')
+ *   @ApiResponse(200, { description: 'The todo item' })
+ *   @ApiResponse(404, { description: 'Todo not found' })
+ *   getById(id: string): Todo | null { ... }
+ * }
+ * ```
+ */
+
+import type { MethodDec } from './types.js';
+
+export interface ApiResponseOptions {
+  /** Human-readable description of this response. */
+  description?: string;
+  /** Type name to use as the response schema (overrides return type inference). */
+  type?: string;
+}
+
+export function ApiResponse(
+  _status: number,
+  _options?: ApiResponseOptions,
+): MethodDec {
+  return (_target, _context) => {
+    // No-op: metadata extracted at compile time by HTTP plugin
+  };
+}

--- a/packages/openapi/src/decorators/schema.ts
+++ b/packages/openapi/src/decorators/schema.ts
@@ -1,0 +1,48 @@
+/**
+ * `@Schema` decorator for custom OpenAPI metadata on `@Introspected` fields.
+ *
+ * No-op at runtime — the introspection plugin scans it at build time and
+ * stores it as `DecoratorMeta { name: 'Schema', args: { ... } }`.
+ * At runtime, `OpenApiSpecBuilder` reads the metadata and applies it
+ * to the generated OpenAPI schema.
+ *
+ * @example
+ * ```typescript
+ * @Introspected()
+ * class CreateTodoDto {
+ *   @Schema({ description: 'The title of the todo item', example: 'Buy milk' })
+ *   @NotBlank()
+ *   accessor title: string;
+ * }
+ * ```
+ */
+
+type FieldDec = (
+  target: undefined,
+  context: ClassFieldDecoratorContext,
+) => void;
+
+export interface SchemaOptions {
+  /** Human-readable description of the field. */
+  description?: string;
+  /** Example value for documentation. */
+  example?: unknown;
+  /** OpenAPI format hint (e.g. 'email', 'uri', 'date-time', 'uuid'). */
+  format?: string;
+  /** Mark the field as deprecated. */
+  deprecated?: boolean;
+  /** Default value. */
+  default?: unknown;
+  /** Restrict to a fixed set of allowed values. */
+  enum?: unknown[];
+  /** Mark the field as read-only. */
+  readOnly?: boolean;
+  /** Mark the field as write-only. */
+  writeOnly?: boolean;
+}
+
+export function Schema(_options: SchemaOptions): FieldDec {
+  return (_target, _context) => {
+    // No-op: metadata extracted at compile time by introspection plugin
+  };
+}

--- a/packages/openapi/src/decorators/types.ts
+++ b/packages/openapi/src/decorators/types.ts
@@ -1,0 +1,5 @@
+/** Stage 3 method decorator signature. */
+export type MethodDec = (
+  target: Function,
+  context: ClassMethodDecoratorContext,
+) => void;

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -1,3 +1,11 @@
+export {
+  ApiOperation,
+  type ApiOperationOptions,
+} from './decorators/api-operation.js';
+export {
+  ApiResponse,
+  type ApiResponseOptions,
+} from './decorators/api-response.js';
 export { Schema, type SchemaOptions } from './decorators/schema.js';
 export { OpenApiConfig } from './openapi-config.js';
 export { OpenApiController } from './openapi-controller.js';

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -1,0 +1,4 @@
+export { Schema, type SchemaOptions } from './decorators/schema.js';
+export { OpenApiConfig } from './openapi-config.js';
+export { OpenApiController } from './openapi-controller.js';
+export { OpenApiSpecBuilder } from './openapi-spec-builder.js';

--- a/packages/openapi/src/openapi-config.ts
+++ b/packages/openapi/src/openapi-config.ts
@@ -1,0 +1,23 @@
+import { ConfigurationProperties, Singleton } from '@goodie-ts/core';
+
+/**
+ * Configuration for OpenAPI spec generation.
+ *
+ * Reads from `openapi.*` config properties:
+ * ```json
+ * {
+ *   "openapi": {
+ *     "title": "My API",
+ *     "version": "1.0.0",
+ *     "description": "A description of the API"
+ *   }
+ * }
+ * ```
+ */
+@Singleton()
+@ConfigurationProperties('openapi')
+export class OpenApiConfig {
+  accessor title: string = 'API';
+  accessor version: string = '0.0.1';
+  accessor description: string = '';
+}

--- a/packages/openapi/src/openapi-controller.ts
+++ b/packages/openapi/src/openapi-controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Response } from '@goodie-ts/http';
+
+import type { OpenApiSpecBuilder } from './openapi-spec-builder.js';
+
+/**
+ * Controller serving the OpenAPI specification.
+ *
+ * Serves the cached OpenAPI spec as JSON at `/openapi.json`.
+ */
+@Controller('/openapi')
+export class OpenApiController {
+  constructor(private readonly specBuilder: OpenApiSpecBuilder) {}
+
+  @Get('.json')
+  spec() {
+    return Response.ok(this.specBuilder.getSpec());
+  }
+}

--- a/packages/openapi/src/openapi-spec-builder.ts
+++ b/packages/openapi/src/openapi-spec-builder.ts
@@ -6,11 +6,7 @@ import {
   Singleton,
   type TypeMetadata,
 } from '@goodie-ts/core';
-import type {
-  ControllerMetadata,
-  ParamMetadata,
-  RouteMetadata,
-} from '@goodie-ts/http';
+import type { ControllerMetadata, RouteMetadata } from '@goodie-ts/http';
 import {
   OpenApiBuilder,
   type OperationObject,
@@ -61,10 +57,12 @@ export class OpenApiSpecBuilder {
     const controllers = this.discoverControllers();
     const schemaNames = new Set<string>();
 
-    for (const { basePath, routes } of controllers) {
-      for (const route of routes) {
-        const fullPath = toOpenApiPath(normalizePath(basePath, route.path));
-        const operation = this.buildOperation(route, schemaNames);
+    for (const { name, metadata: ctrl } of controllers) {
+      for (const route of ctrl.routes) {
+        const fullPath = toOpenApiPath(
+          normalizePath(ctrl.basePath, route.path),
+        );
+        const operation = this.buildOperation(name, route, schemaNames);
 
         const existing =
           (builder.getSpec().paths?.[fullPath] as PathItemObject) ?? {};
@@ -84,26 +82,36 @@ export class OpenApiSpecBuilder {
     return builder.getSpec();
   }
 
-  private discoverControllers(): ControllerMetadata[] {
+  private discoverControllers(): Array<{
+    name: string;
+    metadata: ControllerMetadata;
+  }> {
     const definitions = this.context.getDefinitions();
-    const controllers: ControllerMetadata[] = [];
+    const controllers: Array<{
+      name: string;
+      metadata: ControllerMetadata;
+    }> = [];
 
     for (const def of definitions) {
       const httpCtrl = def.metadata.httpController as
         | ControllerMetadata
         | undefined;
-      if (httpCtrl) controllers.push(httpCtrl);
+      if (!httpCtrl) continue;
+
+      const name = typeof def.token === 'function' ? def.token.name : 'Unknown';
+      controllers.push({ name, metadata: httpCtrl });
     }
 
     return controllers;
   }
 
   private buildOperation(
+    controllerName: string,
     route: RouteMetadata,
     schemaNames: Set<string>,
   ): OperationObject {
     const operation: OperationObject = {
-      operationId: route.methodName,
+      operationId: `${controllerName}_${route.methodName}`,
       responses: {},
     };
 
@@ -210,7 +218,7 @@ export class OpenApiSpecBuilder {
       const hasNull = members.includes('null');
 
       if (schemas.length === 1 && hasNull) {
-        return { ...schemas[0], nullable: true } as SchemaObject;
+        return toNullable(schemas[0]);
       }
       if (schemas.length === 1) return schemas[0];
       return { oneOf: schemas };
@@ -283,10 +291,7 @@ export class OpenApiSpecBuilder {
       case 'optional':
         return this.fieldTypeToSchema(type.inner, schemaNames);
       case 'nullable':
-        return {
-          ...this.fieldTypeToSchema(type.inner, schemaNames),
-          nullable: true,
-        } as SchemaObject;
+        return toNullable(this.fieldTypeToSchema(type.inner, schemaNames));
     }
   }
 
@@ -335,6 +340,21 @@ function literalSchema(value: string): SchemaObject {
   return {};
 }
 
+/**
+ * Make a schema nullable using OAS 3.1 conventions.
+ * - For `$ref`: wraps in `oneOf: [$ref, { type: 'null' }]`
+ * - For inline schemas with `type`: converts to `type: [originalType, 'null']`
+ */
+function toNullable(schema: SchemaObject): SchemaObject {
+  if (schema.$ref) {
+    return { oneOf: [schema, { type: 'null' }] };
+  }
+  if (typeof schema.type === 'string') {
+    return { ...schema, type: [schema.type, 'null'] };
+  }
+  return { oneOf: [schema, { type: 'null' }] };
+}
+
 function isOptionalType(type: FieldType): boolean {
   return type.kind === 'optional';
 }
@@ -372,8 +392,14 @@ function applyConstraints(
         result.format = result.format ?? 'email';
         break;
       case 'Size': {
-        result.minLength = val as number;
-        result.maxLength = dec.args.value2 as number;
+        const isArray = result.type === 'array';
+        if (isArray) {
+          result.minItems = val as number;
+          result.maxItems = dec.args.value2 as number;
+        } else {
+          result.minLength = val as number;
+          result.maxLength = dec.args.value2 as number;
+        }
         break;
       }
     }

--- a/packages/openapi/src/openapi-spec-builder.ts
+++ b/packages/openapi/src/openapi-spec-builder.ts
@@ -12,6 +12,7 @@ import {
   type OperationObject,
   type ParameterObject,
   type PathItemObject,
+  type ResponseObject,
   type SchemaObject,
 } from 'openapi3-ts/oas31';
 
@@ -152,7 +153,11 @@ export class OpenApiSpecBuilder {
       };
     }
 
-    // Response
+    // Apply @ApiOperation metadata
+    const routeDecorators = route.decorators ?? [];
+    applyApiOperation(operation, routeDecorators);
+
+    // Default response from return type
     const responseSchema = this.resolveReturnTypeSchema(
       route.returnType,
       schemaNames,
@@ -170,6 +175,9 @@ export class OpenApiSpecBuilder {
     } else {
       responses[statusCode] = { description: '' };
     }
+
+    // Apply @ApiResponse decorators (override or add response entries)
+    this.applyApiResponses(responses, routeDecorators, schemaNames);
 
     return operation;
   }
@@ -296,6 +304,46 @@ export class OpenApiSpecBuilder {
     }
   }
 
+  /**
+   * Apply @ApiResponse decorators to the responses object.
+   * Each decorator adds or overrides a response entry for the given status code.
+   */
+  private applyApiResponses(
+    responses: Record<string, ResponseObject>,
+    decorators: DecoratorMeta[],
+    schemaNames: Set<string>,
+  ): void {
+    for (const dec of decorators) {
+      if (dec.name !== 'ApiResponse') continue;
+
+      const status = String(dec.args.value);
+      const options = (dec.args.value2 ?? {}) as Record<string, unknown>;
+      const description = (options.description as string) ?? '';
+      const typeName = options.type as string | undefined;
+
+      if (typeName) {
+        if (!this.findMetadataByName(typeName)) {
+          console.warn(
+            `[openapi] @ApiResponse references type '${typeName}' which is not @Introspected — schema will be empty`,
+          );
+        }
+        const schema = this.resolveTypeSchema(typeName, schemaNames);
+        responses[status] = {
+          description,
+          content: { 'application/json': { schema } },
+        };
+      } else {
+        // Update description on existing response, or add a bodiless one
+        const existing = responses[status];
+        if (existing) {
+          existing.description = description;
+        } else {
+          responses[status] = { description };
+        }
+      }
+    }
+  }
+
   private findMetadataByName(className: string): TypeMetadata | undefined {
     return MetadataRegistry.INSTANCE.getAll().find(
       (m) => m.className === className,
@@ -304,6 +352,23 @@ export class OpenApiSpecBuilder {
 }
 
 // ── Helpers ──
+
+/** Apply `@ApiOperation` decorator metadata to the operation object. */
+function applyApiOperation(
+  operation: OperationObject,
+  decorators: DecoratorMeta[],
+): void {
+  const dec = decorators.find((d) => d.name === 'ApiOperation');
+  if (!dec) return;
+
+  const args = dec.args;
+  if (args.summary !== undefined) operation.summary = args.summary as string;
+  if (args.description !== undefined)
+    operation.description = args.description as string;
+  if (args.tags !== undefined) operation.tags = args.tags as string[];
+  if (args.deprecated !== undefined)
+    operation.deprecated = args.deprecated as boolean;
+}
 
 function normalizePath(basePath: string, routePath: string): string {
   const base = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;

--- a/packages/openapi/src/openapi-spec-builder.ts
+++ b/packages/openapi/src/openapi-spec-builder.ts
@@ -1,0 +1,409 @@
+import {
+  type ApplicationContext,
+  type DecoratorMeta,
+  type FieldType,
+  MetadataRegistry,
+  Singleton,
+  type TypeMetadata,
+} from '@goodie-ts/core';
+import type {
+  ControllerMetadata,
+  ParamMetadata,
+  RouteMetadata,
+} from '@goodie-ts/http';
+import {
+  OpenApiBuilder,
+  type OperationObject,
+  type ParameterObject,
+  type PathItemObject,
+  type SchemaObject,
+} from 'openapi3-ts/oas31';
+
+import type { OpenApiConfig } from './openapi-config.js';
+
+/**
+ * Builds an OpenAPI 3.1 spec from runtime introspection metadata
+ * and controller route metadata.
+ *
+ * Reads from two sources:
+ * - `MetadataRegistry` for `@Introspected` type shapes and constraints
+ * - `ApplicationContext.getDefinitions()` for `ControllerMetadata` on controllers
+ *
+ * The spec is built once on first access and cached.
+ */
+@Singleton()
+export class OpenApiSpecBuilder {
+  private cachedSpec: object | undefined;
+
+  constructor(
+    private readonly context: ApplicationContext,
+    private readonly config: OpenApiConfig,
+  ) {}
+
+  /** Get the OpenAPI spec object, building it on first call. */
+  getSpec(): object {
+    if (this.cachedSpec) return this.cachedSpec;
+    this.cachedSpec = this.buildSpec();
+    return this.cachedSpec;
+  }
+
+  private buildSpec(): object {
+    const builder = OpenApiBuilder.create()
+      .addOpenApiVersion('3.1.0')
+      .addInfo({
+        title: this.config.title,
+        version: this.config.version,
+        ...(this.config.description
+          ? { description: this.config.description }
+          : {}),
+      });
+
+    const controllers = this.discoverControllers();
+    const schemaNames = new Set<string>();
+
+    for (const { basePath, routes } of controllers) {
+      for (const route of routes) {
+        const fullPath = toOpenApiPath(normalizePath(basePath, route.path));
+        const operation = this.buildOperation(route, schemaNames);
+
+        const existing =
+          (builder.getSpec().paths?.[fullPath] as PathItemObject) ?? {};
+        existing[route.httpMethod] = operation;
+        builder.addPath(fullPath, existing);
+      }
+    }
+
+    // Add all referenced schemas as components
+    for (const name of schemaNames) {
+      const metadata = this.findMetadataByName(name);
+      if (metadata) {
+        builder.addSchema(name, this.buildObjectSchema(metadata, schemaNames));
+      }
+    }
+
+    return builder.getSpec();
+  }
+
+  private discoverControllers(): ControllerMetadata[] {
+    const definitions = this.context.getDefinitions();
+    const controllers: ControllerMetadata[] = [];
+
+    for (const def of definitions) {
+      const httpCtrl = def.metadata.httpController as
+        | ControllerMetadata
+        | undefined;
+      if (httpCtrl) controllers.push(httpCtrl);
+    }
+
+    return controllers;
+  }
+
+  private buildOperation(
+    route: RouteMetadata,
+    schemaNames: Set<string>,
+  ): OperationObject {
+    const operation: OperationObject = {
+      operationId: route.methodName,
+      responses: {},
+    };
+
+    // Parameters (path + query)
+    const parameters: ParameterObject[] = [];
+    let requestBodySchema: SchemaObject | undefined;
+
+    for (const param of route.params) {
+      if (param.binding === 'path') {
+        parameters.push({
+          name: param.name,
+          in: 'path',
+          required: !param.optional,
+          schema: primitiveSchema(param.typeName),
+        });
+      } else if (param.binding === 'query') {
+        parameters.push({
+          name: param.name,
+          in: 'query',
+          required: !param.optional,
+          schema: primitiveSchema(param.typeName),
+        });
+      } else if (param.binding === 'body') {
+        requestBodySchema = this.resolveTypeSchema(param.typeName, schemaNames);
+      }
+    }
+
+    if (parameters.length > 0) {
+      operation.parameters = parameters;
+    }
+
+    if (requestBodySchema) {
+      operation.requestBody = {
+        required: true,
+        content: {
+          'application/json': { schema: requestBodySchema },
+        },
+      };
+    }
+
+    // Response
+    const responseSchema = this.resolveReturnTypeSchema(
+      route.returnType,
+      schemaNames,
+    );
+    const statusCode = String(route.status);
+
+    if (responseSchema) {
+      operation.responses[statusCode] = {
+        description: '',
+        content: {
+          'application/json': { schema: responseSchema },
+        },
+      };
+    } else {
+      operation.responses[statusCode] = { description: '' };
+    }
+
+    return operation;
+  }
+
+  /**
+   * Resolve a type name (from ParamMetadata.typeName) to an OpenAPI schema.
+   * For known @Introspected types, returns a $ref. For primitives, returns inline.
+   */
+  private resolveTypeSchema(
+    typeName: string,
+    schemaNames: Set<string>,
+  ): SchemaObject {
+    const metadata = this.findMetadataByName(typeName);
+    if (metadata) {
+      schemaNames.add(typeName);
+      return { $ref: `#/components/schemas/${typeName}` };
+    }
+    return primitiveSchema(typeName);
+  }
+
+  /**
+   * Resolve a return type string to an OpenAPI schema.
+   * Handles: class names, arrays (Todo[]), unions (Todo | null), void.
+   */
+  private resolveReturnTypeSchema(
+    returnType: string,
+    schemaNames: Set<string>,
+  ): SchemaObject | undefined {
+    if (returnType === 'void') return undefined;
+
+    // Array: "ClassName[]"
+    if (returnType.endsWith('[]')) {
+      const elementType = returnType.slice(0, -2).trim();
+      return {
+        type: 'array',
+        items: this.resolveTypeSchema(elementType, schemaNames),
+      };
+    }
+
+    // Union: "A | B"
+    if (returnType.includes(' | ')) {
+      const members = returnType.split(' | ').map((s) => s.trim());
+      const schemas = members
+        .filter((m) => m !== 'null' && m !== 'undefined')
+        .map((m) => this.resolveTypeSchema(m, schemaNames));
+
+      const hasNull = members.includes('null');
+
+      if (schemas.length === 1 && hasNull) {
+        return { ...schemas[0], nullable: true } as SchemaObject;
+      }
+      if (schemas.length === 1) return schemas[0];
+      return { oneOf: schemas };
+    }
+
+    // Single type
+    return this.resolveTypeSchema(returnType, schemaNames);
+  }
+
+  /** Build an object schema from TypeMetadata with field types and constraints. */
+  private buildObjectSchema(
+    metadata: TypeMetadata,
+    schemaNames: Set<string>,
+  ): SchemaObject {
+    const properties: Record<string, SchemaObject> = {};
+    const required: string[] = [];
+
+    for (const field of metadata.fields) {
+      const fieldSchema = this.fieldTypeToSchema(field.type, schemaNames);
+      const withConstraints = applyConstraints(fieldSchema, field.decorators);
+      const withSchemaDecorator = applySchemaDecorator(
+        withConstraints,
+        field.decorators,
+      );
+      properties[field.name] = withSchemaDecorator;
+
+      if (!isOptionalType(field.type)) {
+        required.push(field.name);
+      }
+    }
+
+    const schema: SchemaObject = { type: 'object', properties };
+    if (required.length > 0) schema.required = required;
+    return schema;
+  }
+
+  private fieldTypeToSchema(
+    type: FieldType,
+    schemaNames: Set<string>,
+  ): SchemaObject {
+    switch (type.kind) {
+      case 'primitive':
+        return primitiveSchema(type.type);
+      case 'literal':
+        return literalSchema(type.value);
+      case 'array':
+        return {
+          type: 'array',
+          items: this.fieldTypeToSchema(type.elementType, schemaNames),
+        };
+      case 'reference': {
+        const metadata = this.findMetadataByName(type.className);
+        if (metadata) {
+          schemaNames.add(type.className);
+          return { $ref: `#/components/schemas/${type.className}` };
+        }
+        return {};
+      }
+      case 'union': {
+        const schemas = type.types
+          .filter(
+            (t) =>
+              !(t.kind === 'primitive' && t.type === 'undefined') &&
+              !(t.kind === 'primitive' && t.type === 'null'),
+          )
+          .map((t) => this.fieldTypeToSchema(t, schemaNames));
+        if (schemas.length === 1) return schemas[0];
+        return { oneOf: schemas };
+      }
+      case 'optional':
+        return this.fieldTypeToSchema(type.inner, schemaNames);
+      case 'nullable':
+        return {
+          ...this.fieldTypeToSchema(type.inner, schemaNames),
+          nullable: true,
+        } as SchemaObject;
+    }
+  }
+
+  private findMetadataByName(className: string): TypeMetadata | undefined {
+    return MetadataRegistry.INSTANCE.getAll().find(
+      (m) => m.className === className,
+    );
+  }
+}
+
+// ── Helpers ──
+
+function normalizePath(basePath: string, routePath: string): string {
+  const base = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+  const route = routePath.startsWith('/') ? routePath : `/${routePath}`;
+  return route === '/' ? base || '/' : `${base}${route}`;
+}
+
+/** Convert Express-style `:param` to OpenAPI `{param}`. */
+function toOpenApiPath(path: string): string {
+  return path.replace(/:([a-zA-Z_]\w*)/g, '{$1}');
+}
+
+function primitiveSchema(typeName: string): SchemaObject {
+  switch (typeName) {
+    case 'string':
+      return { type: 'string' };
+    case 'number':
+      return { type: 'number' };
+    case 'boolean':
+      return { type: 'boolean' };
+    default:
+      return {};
+  }
+}
+
+function literalSchema(value: string): SchemaObject {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    const str = value.slice(1, -1);
+    return { type: 'string', enum: [str] };
+  }
+  if (value === 'true') return { type: 'boolean', enum: [true] };
+  if (value === 'false') return { type: 'boolean', enum: [false] };
+  const num = Number(value);
+  if (!Number.isNaN(num)) return { type: 'number', enum: [num] };
+  return {};
+}
+
+function isOptionalType(type: FieldType): boolean {
+  return type.kind === 'optional';
+}
+
+/** Map well-known constraint decorators to OpenAPI schema properties. */
+function applyConstraints(
+  schema: SchemaObject,
+  decorators: DecoratorMeta[],
+): SchemaObject {
+  const result = { ...schema };
+
+  for (const dec of decorators) {
+    const val = dec.args.value;
+
+    switch (dec.name) {
+      case 'MinLength':
+        result.minLength = val as number;
+        break;
+      case 'MaxLength':
+        result.maxLength = val as number;
+        break;
+      case 'Min':
+        result.minimum = val as number;
+        break;
+      case 'Max':
+        result.maximum = val as number;
+        break;
+      case 'Pattern':
+        result.pattern = val as string;
+        break;
+      case 'NotBlank':
+        result.minLength = result.minLength ?? 1;
+        break;
+      case 'Email':
+        result.format = result.format ?? 'email';
+        break;
+      case 'Size': {
+        result.minLength = val as number;
+        result.maxLength = dec.args.value2 as number;
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Apply `@Schema` decorator metadata to the schema. */
+function applySchemaDecorator(
+  schema: SchemaObject,
+  decorators: DecoratorMeta[],
+): SchemaObject {
+  const schemaDec = decorators.find((d) => d.name === 'Schema');
+  if (!schemaDec) return schema;
+
+  const result = { ...schema };
+  const args = schemaDec.args;
+
+  if (args.description !== undefined)
+    result.description = args.description as string;
+  if (args.example !== undefined) result.example = args.example;
+  if (args.format !== undefined) result.format = args.format as string;
+  if (args.deprecated !== undefined)
+    result.deprecated = args.deprecated as boolean;
+  if (args.default !== undefined) result.default = args.default;
+  if (args.enum !== undefined) result.enum = args.enum as unknown[];
+  if (args.readOnly !== undefined) result.readOnly = args.readOnly as boolean;
+  if (args.writeOnly !== undefined)
+    result.writeOnly = args.writeOnly as boolean;
+
+  return result;
+}

--- a/packages/openapi/src/openapi-spec-builder.ts
+++ b/packages/openapi/src/openapi-spec-builder.ts
@@ -159,15 +159,16 @@ export class OpenApiSpecBuilder {
     );
     const statusCode = String(route.status);
 
+    const responses = operation.responses!;
     if (responseSchema) {
-      operation.responses[statusCode] = {
+      responses[statusCode] = {
         description: '',
         content: {
           'application/json': { schema: responseSchema },
         },
       };
     } else {
-      operation.responses[statusCode] = { description: '' };
+      responses[statusCode] = { description: '' };
     }
 
     return operation;

--- a/packages/openapi/tsconfig.json
+++ b/packages/openapi/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/transformer/src/builtin-introspection-plugin.ts
+++ b/packages/transformer/src/builtin-introspection-plugin.ts
@@ -1,23 +1,15 @@
-import {
-  type ClassDeclaration,
-  type Decorator,
-  type Node,
-  SyntaxKind,
-  type Type,
-} from 'ts-morph';
+import type { ClassDeclaration, Type } from 'ts-morph';
+import { extractDecoratorMeta } from './decorator-utils.js';
 import type { ClassVisitorContext, TransformerPlugin } from './options.js';
 
 // ── Scanned introspection data (intermediate representation) ──
 
-interface ScannedDecoratorMeta {
-  name: string;
-  args: Record<string, unknown>;
-}
+import type { ParsedDecoratorMeta } from './decorator-utils.js';
 
 interface ScannedIntrospectedField {
   name: string;
   type: ScannedFieldType;
-  decorators: ScannedDecoratorMeta[];
+  decorators: ParsedDecoratorMeta[];
 }
 
 type ScannedFieldType =
@@ -92,110 +84,15 @@ function scanClassFields(cls: ClassDeclaration): ScannedIntrospectedField[] {
     const fieldType = resolveFieldType(propType);
 
     // Extract all field decorators generically
-    const decorators = extractFieldDecorators(prop.getDecorators());
+    const decorators = extractDecoratorMeta(
+      prop.getDecorators(),
+      IGNORED_DECORATORS,
+    );
 
     fields.push({ name, type: fieldType, decorators });
   }
 
   return fields;
-}
-
-function extractFieldDecorators(
-  decorators: Decorator[],
-): ScannedDecoratorMeta[] {
-  const result: ScannedDecoratorMeta[] = [];
-
-  for (const dec of decorators) {
-    const name = dec.getName();
-    if (IGNORED_DECORATORS.has(name)) continue;
-
-    const callExpr = dec.getCallExpression();
-    const astArgs = callExpr ? callExpr.getArguments() : [];
-
-    const args = parseDecoratorArgs(astArgs);
-
-    result.push({ name, args });
-  }
-
-  return result;
-}
-
-function parseDecoratorArgs(args: Node[]): Record<string, unknown> {
-  if (args.length === 0) return {};
-
-  // Single object literal argument → parse its properties via AST
-  if (
-    args.length === 1 &&
-    args[0].getKind() === SyntaxKind.ObjectLiteralExpression
-  ) {
-    return parseObjectLiteralNode(args[0]);
-  }
-
-  // Single positional argument → { value: <parsed> }
-  if (args.length === 1) {
-    return { value: parseNodeValue(args[0]) };
-  }
-
-  // Multiple positional args → { value: first, value2: second, ... }
-  const result: Record<string, unknown> = {};
-  for (let i = 0; i < args.length; i++) {
-    result[i === 0 ? 'value' : `value${i + 1}`] = parseNodeValue(args[i]);
-  }
-  return result;
-}
-
-function parseNodeValue(node: Node): unknown {
-  const kind = node.getKind();
-
-  // String literal
-  if (kind === SyntaxKind.StringLiteral) {
-    const text = node.getText();
-    return text.slice(1, -1);
-  }
-
-  // Numeric literal
-  if (kind === SyntaxKind.NumericLiteral) {
-    return Number(node.getText());
-  }
-
-  // Negative number: PrefixUnaryExpression with minus + NumericLiteral
-  if (kind === SyntaxKind.PrefixUnaryExpression) {
-    const text = node.getText();
-    const num = Number(text);
-    if (!Number.isNaN(num)) return num;
-  }
-
-  // Boolean literals
-  if (kind === SyntaxKind.TrueKeyword) return true;
-  if (kind === SyntaxKind.FalseKeyword) return false;
-
-  // Array literal
-  if (kind === SyntaxKind.ArrayLiteralExpression) {
-    const arrayExpr = node.asKind(SyntaxKind.ArrayLiteralExpression)!;
-    return arrayExpr.getElements().map((el) => parseNodeValue(el));
-  }
-
-  // Object literal (nested)
-  if (kind === SyntaxKind.ObjectLiteralExpression) {
-    return parseObjectLiteralNode(node);
-  }
-
-  // Fallback: raw text
-  return node.getText();
-}
-
-function parseObjectLiteralNode(node: Node): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-
-  for (const prop of node.getChildrenOfKind(SyntaxKind.PropertyAssignment)) {
-    const key = prop.getChildAtIndex(0).getText();
-    const initializer = prop.getInitializer();
-    if (initializer) {
-      result[key] = parseNodeValue(initializer);
-    }
-  }
-
-  return result;
 }
 
 // ── Type resolution ──

--- a/packages/transformer/src/decorator-utils.ts
+++ b/packages/transformer/src/decorator-utils.ts
@@ -1,0 +1,110 @@
+import { type Decorator, type Node, SyntaxKind } from 'ts-morph';
+
+/** Parsed decorator metadata — name and arguments as key-value pairs. */
+export interface ParsedDecoratorMeta {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Extract decorator metadata from an array of ts-morph Decorator nodes.
+ * Skips decorators in the optional `ignore` set.
+ */
+export function extractDecoratorMeta(
+  decorators: Decorator[],
+  ignore?: Set<string>,
+): ParsedDecoratorMeta[] {
+  const result: ParsedDecoratorMeta[] = [];
+
+  for (const dec of decorators) {
+    const name = dec.getName();
+    if (ignore?.has(name)) continue;
+
+    const callExpr = dec.getCallExpression();
+    const astArgs = callExpr ? callExpr.getArguments() : [];
+
+    const args = parseDecoratorArgs(astArgs);
+
+    result.push({ name, args });
+  }
+
+  return result;
+}
+
+export function parseDecoratorArgs(args: Node[]): Record<string, unknown> {
+  if (args.length === 0) return {};
+
+  // Single object literal argument → parse its properties via AST
+  if (
+    args.length === 1 &&
+    args[0].getKind() === SyntaxKind.ObjectLiteralExpression
+  ) {
+    return parseObjectLiteralNode(args[0]);
+  }
+
+  // Single positional argument → { value: <parsed> }
+  if (args.length === 1) {
+    return { value: parseNodeValue(args[0]) };
+  }
+
+  // Multiple positional args → { value: first, value2: second, ... }
+  const result: Record<string, unknown> = {};
+  for (let i = 0; i < args.length; i++) {
+    result[i === 0 ? 'value' : `value${i + 1}`] = parseNodeValue(args[i]);
+  }
+  return result;
+}
+
+export function parseNodeValue(node: Node): unknown {
+  const kind = node.getKind();
+
+  // String literal
+  if (kind === SyntaxKind.StringLiteral) {
+    const text = node.getText();
+    return text.slice(1, -1);
+  }
+
+  // Numeric literal
+  if (kind === SyntaxKind.NumericLiteral) {
+    return Number(node.getText());
+  }
+
+  // Negative number: PrefixUnaryExpression with minus + NumericLiteral
+  if (kind === SyntaxKind.PrefixUnaryExpression) {
+    const text = node.getText();
+    const num = Number(text);
+    if (!Number.isNaN(num)) return num;
+  }
+
+  // Boolean literals
+  if (kind === SyntaxKind.TrueKeyword) return true;
+  if (kind === SyntaxKind.FalseKeyword) return false;
+
+  // Array literal
+  if (kind === SyntaxKind.ArrayLiteralExpression) {
+    const arrayExpr = node.asKind(SyntaxKind.ArrayLiteralExpression)!;
+    return arrayExpr.getElements().map((el) => parseNodeValue(el));
+  }
+
+  // Object literal (nested)
+  if (kind === SyntaxKind.ObjectLiteralExpression) {
+    return parseObjectLiteralNode(node);
+  }
+
+  // Fallback: raw text
+  return node.getText();
+}
+
+function parseObjectLiteralNode(node: Node): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const prop of node.getChildrenOfKind(SyntaxKind.PropertyAssignment)) {
+    const key = prop.getChildAtIndex(0).getText();
+    const initializer = prop.getInitializer();
+    if (initializer) {
+      result[key] = parseNodeValue(initializer);
+    }
+  }
+
+  return result;
+}

--- a/packages/transformer/src/index.ts
+++ b/packages/transformer/src/index.ts
@@ -18,6 +18,9 @@ export { createIntrospectionPlugin } from './builtin-introspection-plugin.js';
 export type { CodegenOptions, TypeRegistration } from './codegen.js';
 // Code Generator
 export { generateCode } from './codegen.js';
+// Decorator parsing utilities
+export type { ParsedDecoratorMeta } from './decorator-utils.js';
+export { extractDecoratorMeta } from './decorator-utils.js';
 // Plugin discovery
 export type { DiscoverAllResult } from './discover-plugins.js';
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,30 @@ importers:
         specifier: ^24.0.0
         version: 24.0.0
 
+  packages/openapi:
+    devDependencies:
+      '@goodie-ts/cli':
+        specifier: workspace:*
+        version: link:../cli
+      '@goodie-ts/core':
+        specifier: workspace:*
+        version: link:../core
+      '@goodie-ts/http':
+        specifier: workspace:*
+        version: link:../http
+      '@goodie-ts/transformer':
+        specifier: workspace:*
+        version: link:../transformer
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      openapi3-ts:
+        specifier: ^4.4.0
+        version: 4.5.0
+      ts-morph:
+        specifier: ^24.0.0
+        version: 24.0.0
+
   packages/resilience:
     devDependencies:
       '@goodie-ts/cli':
@@ -1936,6 +1960,9 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -4007,6 +4034,10 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.2
 
   outdent@0.5.0: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,6 +68,10 @@ export default defineConfig({
         __dirname,
         'packages/management/src/index.ts',
       ),
+      '@goodie-ts/openapi': path.resolve(
+        __dirname,
+        'packages/openapi/src/index.ts',
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

New `@goodie-ts/openapi` package that builds OpenAPI 3.1 specs at runtime from compile-time introspection metadata and controller route metadata.

- **OpenApiSpecBuilder** — `@Singleton` that reads `MetadataRegistry` (type shapes, constraints) and `ControllerMetadata` (routes, params) from `ApplicationContext.getDefinitions()`. Built once on first access, cached.
- **OpenApiController** — `@Controller('/openapi')` with `@Get('.json')` serving the cached spec
- **OpenApiConfig** — `@ConfigurationProperties('openapi')` for title, version, description
- **`@Schema` decorator** — custom OpenAPI metadata (description, example, format, enum, deprecated, etc.) on `@Introspected` fields
- Maps well-known constraint decorators to OpenAPI schema properties: `MinLength` → `minLength`, `Email` → `format: email`, `Pattern` → `pattern`, `Min`/`Max` → `minimum`/`maximum`, `Size` → `minLength`+`maxLength`, `NotBlank` → `minLength: 1`
- Handles nested `@Introspected` references as `$ref`, arrays, unions, nullable/optional types
- Converts `:param` → `{param}` in paths for OpenAPI compliance
- Uses `openapi3-ts` (~15KB) as a peer dependency for spec building

Closes #107

## Test plan

- 17 new tests covering spec builder (routes, params, body schemas, response types, constraint mapping, `@Schema` decorator, nested refs, optional fields, caching, void returns, status codes, path merging) and controller
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (962 tests, 82 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)