### PR TITLE
feat: add @Primary bean qualifier decorator (#101)

### DIFF
--- a/packages/core/__tests__/application-context.test.ts
+++ b/packages/core/__tests__/application-context.test.ts
@@ -1234,6 +1234,131 @@ describe('ApplicationContext — self-injection', () => {
   });
 });
 
+// ── @Primary ────────────────────────────────────────────────────────
+
+describe('ApplicationContext — @Primary', () => {
+  it('selects @Primary bean over last-registered bean', async () => {
+    const token = new InjectionToken<object>('Provider');
+
+    class PrimaryImpl {
+      id = 'primary';
+    }
+    class SecondaryImpl {
+      id = 'secondary';
+    }
+
+    const ctx = await ApplicationContext.create([
+      makeDef(PrimaryImpl, {
+        factory: () => new PrimaryImpl(),
+        metadata: { primary: true },
+      }),
+      makeDef(SecondaryImpl, { factory: () => new SecondaryImpl() }),
+    ]);
+
+    // PrimaryImpl should win even though SecondaryImpl was registered last
+    expect(ctx.get(PrimaryImpl)).toBeInstanceOf(PrimaryImpl);
+  });
+
+  it('selects @Primary bean under shared base token', async () => {
+    abstract class CacheProvider {}
+
+    class InMemoryCache extends CacheProvider {
+      type = 'memory';
+    }
+    class RedisCache extends CacheProvider {
+      type = 'redis';
+    }
+
+    const ctx = await ApplicationContext.create([
+      {
+        token: InMemoryCache,
+        scope: 'singleton',
+        dependencies: [],
+        factory: () => new InMemoryCache(),
+        eager: false,
+        metadata: { primary: true },
+        baseTokens: [CacheProvider],
+      },
+      {
+        token: RedisCache,
+        scope: 'singleton',
+        dependencies: [],
+        factory: () => new RedisCache(),
+        eager: false,
+        metadata: {},
+        baseTokens: [CacheProvider],
+      },
+    ]);
+
+    // InMemoryCache is @Primary, so get(CacheProvider) should return it
+    const provider = ctx.get(CacheProvider);
+    expect(provider).toBeInstanceOf(InMemoryCache);
+  });
+
+  it('getAll still returns all beans regardless of @Primary', async () => {
+    abstract class Handler {}
+
+    class HandlerA extends Handler {}
+    class HandlerB extends Handler {}
+
+    const ctx = await ApplicationContext.create([
+      {
+        token: HandlerA,
+        scope: 'singleton',
+        dependencies: [],
+        factory: () => new HandlerA(),
+        eager: false,
+        metadata: { primary: true },
+        baseTokens: [Handler],
+      },
+      {
+        token: HandlerB,
+        scope: 'singleton',
+        dependencies: [],
+        factory: () => new HandlerB(),
+        eager: false,
+        metadata: {},
+        baseTokens: [Handler],
+      },
+    ]);
+
+    const all = ctx.getAll(Handler);
+    expect(all).toHaveLength(2);
+  });
+
+  it('falls back to last-wins when no @Primary is set', async () => {
+    abstract class Formatter {}
+
+    class JsonFormatter extends Formatter {}
+    class XmlFormatter extends Formatter {}
+
+    const ctx = await ApplicationContext.create([
+      {
+        token: JsonFormatter,
+        scope: 'singleton',
+        dependencies: [],
+        factory: () => new JsonFormatter(),
+        eager: false,
+        metadata: {},
+        baseTokens: [Formatter],
+      },
+      {
+        token: XmlFormatter,
+        scope: 'singleton',
+        dependencies: [],
+        factory: () => new XmlFormatter(),
+        eager: false,
+        metadata: {},
+        baseTokens: [Formatter],
+      },
+    ]);
+
+    // Last registered wins when no @Primary
+    const formatter = ctx.get(Formatter);
+    expect(formatter).toBeInstanceOf(XmlFormatter);
+  });
+});
+
 // ── Helper ───────────────────────────────────────────────────────────
 
 function tokenDesc(token: unknown): string {

--- a/packages/core/__tests__/application-context.test.ts
+++ b/packages/core/__tests__/application-context.test.ts
@@ -1237,26 +1237,40 @@ describe('ApplicationContext — self-injection', () => {
 // ── @Primary ────────────────────────────────────────────────────────
 
 describe('ApplicationContext — @Primary', () => {
-  it('selects @Primary bean over last-registered bean', async () => {
-    const token = new InjectionToken<object>('Provider');
+  it('selects @Primary bean over last-registered bean via shared token', async () => {
+    abstract class Provider {}
 
-    class PrimaryImpl {
+    class PrimaryImpl extends Provider {
       id = 'primary';
     }
-    class SecondaryImpl {
+    class SecondaryImpl extends Provider {
       id = 'secondary';
     }
 
     const ctx = await ApplicationContext.create([
-      makeDef(PrimaryImpl, {
+      {
+        token: PrimaryImpl,
+        scope: 'singleton',
+        dependencies: [],
         factory: () => new PrimaryImpl(),
+        eager: false,
         metadata: { primary: true },
-      }),
-      makeDef(SecondaryImpl, { factory: () => new SecondaryImpl() }),
+        baseTokens: [Provider],
+      },
+      {
+        token: SecondaryImpl,
+        scope: 'singleton',
+        dependencies: [],
+        factory: () => new SecondaryImpl(),
+        eager: false,
+        metadata: {},
+        baseTokens: [Provider],
+      },
     ]);
 
     // PrimaryImpl should win even though SecondaryImpl was registered last
-    expect(ctx.get(PrimaryImpl)).toBeInstanceOf(PrimaryImpl);
+    const provider = ctx.get(Provider);
+    expect(provider).toBeInstanceOf(PrimaryImpl);
   });
 
   it('selects @Primary bean under shared base token', async () => {

--- a/packages/core/src/application-context.ts
+++ b/packages/core/src/application-context.ts
@@ -52,8 +52,15 @@ export class ApplicationContext {
       } else {
         this.defsByToken.set(def.token, [def]);
       }
-      // Last definition wins as primary (matches typical DI override semantics)
-      this.primaryDef.set(def.token, def);
+      // @Primary wins; otherwise last definition wins (typical DI override semantics)
+      const currentPrimary = this.primaryDef.get(def.token);
+      if (
+        !currentPrimary ||
+        def.metadata.primary ||
+        !currentPrimary.metadata.primary
+      ) {
+        this.primaryDef.set(def.token, def);
+      }
 
       // Register under base tokens so getAll(BaseClass) finds subtypes
       if (def.baseTokens) {
@@ -64,7 +71,14 @@ export class ApplicationContext {
           } else {
             this.defsByToken.set(baseToken, [def]);
           }
-          this.primaryDef.set(baseToken, def);
+          const currentBasePrimary = this.primaryDef.get(baseToken);
+          if (
+            !currentBasePrimary ||
+            def.metadata.primary ||
+            !currentBasePrimary.metadata.primary
+          ) {
+            this.primaryDef.set(baseToken, def);
+          }
         }
       }
     }

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -24,6 +24,7 @@ export { Order } from './order.js';
 export { PostConstruct } from './post-construct.js';
 export { PostProcessor } from './post-processor.js';
 export { PreDestroy } from './pre-destroy.js';
+export { Primary } from './primary.js';
 export { Provides } from './provides.js';
 export { RequestScoped } from './request-scoped.js';
 export { Singleton } from './singleton.js';

--- a/packages/core/src/decorators/primary.ts
+++ b/packages/core/src/decorators/primary.ts
@@ -1,0 +1,23 @@
+/**
+ * Marks a bean as the default (primary) when multiple beans match a dependency type.
+ *
+ * When multiple beans are registered under the same token, the container selects
+ * the `@Primary` bean for injection unless the injection point specifies a qualifier
+ * (e.g. `@Inject('name')`).
+ *
+ * **Compile-time only** — the decorator is a no-op marker at runtime.
+ * The transformer reads this decorator via AST inspection at build time.
+ *
+ * @example
+ * @Primary
+ * @Singleton()
+ * class InMemoryCache implements CacheProvider { ... }
+ *
+ * @Named('redis')
+ * @Singleton()
+ * class RedisCache implements CacheProvider { ... }
+ */
+export function Primary(
+  _target: new (...args: any[]) => any,
+  _context: ClassDecoratorContext,
+): void {}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export {
   PostConstruct,
   PostProcessor,
   PreDestroy,
+  Primary,
   Provides,
   RequestScoped,
   Singleton,

--- a/packages/events/src/events-transformer-plugin.ts
+++ b/packages/events/src/events-transformer-plugin.ts
@@ -76,6 +76,7 @@ export function createEventsPlugin(): TransformerPlugin {
         scope: 'singleton',
         eager: true,
         name: undefined,
+        primary: false,
         constructorDeps: [
           {
             tokenRef: {

--- a/packages/kysely/__tests__/kysely-plugin.test.ts
+++ b/packages/kysely/__tests__/kysely-plugin.test.ts
@@ -24,6 +24,7 @@ const kyselyDatabaseLibraryBean: IRBeanDefinition = {
   scope: 'singleton',
   eager: false,
   name: undefined,
+  primary: false,
   constructorDeps: [],
   fieldDeps: [],
   factoryKind: 'constructor',
@@ -46,6 +47,7 @@ const transactionManagerLibraryBean: IRBeanDefinition = {
   scope: 'singleton',
   eager: false,
   name: undefined,
+  primary: false,
   constructorDeps: [
     {
       tokenRef: {
@@ -79,6 +81,7 @@ const transactionalInterceptorLibraryBean: IRBeanDefinition = {
   scope: 'singleton',
   eager: false,
   name: undefined,
+  primary: false,
   constructorDeps: [
     {
       tokenRef: {
@@ -112,6 +115,7 @@ const migrationRunnerLibraryBean: IRBeanDefinition = {
   scope: 'singleton',
   eager: true,
   name: undefined,
+  primary: false,
   constructorDeps: [
     {
       tokenRef: {

--- a/packages/scheduler/src/scheduler-transformer-plugin.ts
+++ b/packages/scheduler/src/scheduler-transformer-plugin.ts
@@ -131,6 +131,7 @@ export function createSchedulerPlugin(): TransformerPlugin {
         scope: 'singleton',
         eager: true,
         name: undefined,
+        primary: false,
         constructorDeps: [
           {
             tokenRef: {

--- a/packages/transformer/__tests__/graph-builder.test.ts
+++ b/packages/transformer/__tests__/graph-builder.test.ts
@@ -32,6 +32,7 @@ const decoratorsFile = `
   export function Provides() { return (t: any, c: any) => {} }
   export function Inject(q: any) { return (t: any, c: any) => {} }
   export function Optional() { return (t: any, c: any) => {} }
+  export function Primary(t: any, c: any) {}
 `;
 
 describe('Graph Builder', () => {
@@ -297,6 +298,58 @@ describe('Graph Builder', () => {
         kind: 'class',
         className: 'Repo',
       });
+    });
+  });
+
+  describe('@Primary validation', () => {
+    it('should propagate primary flag through the pipeline', () => {
+      const result = pipeline({
+        '/src/decorators.ts': decoratorsFile,
+        '/src/DefaultRepo.ts': `
+          import { Singleton, Primary } from './decorators.js'
+
+          @Primary
+          @Singleton()
+          export class DefaultRepo {}
+        `,
+      });
+
+      const bean = result.beans.find(
+        (b) =>
+          b.tokenRef.kind === 'class' && b.tokenRef.className === 'DefaultRepo',
+      )!;
+      expect(bean.primary).toBe(true);
+      expect(bean.metadata.primary).toBe(true);
+    });
+
+    it('should set primary metadata to true in generated code', () => {
+      const result = pipeline({
+        '/src/decorators.ts': decoratorsFile,
+        '/src/DefaultRepo.ts': `
+          import { Singleton, Primary } from './decorators.js'
+
+          @Primary
+          @Singleton()
+          export class DefaultRepo {}
+        `,
+        '/src/OtherRepo.ts': `
+          import { Singleton } from './decorators.js'
+
+          @Singleton()
+          export class OtherRepo {}
+        `,
+      });
+
+      const defaultBean = result.beans.find(
+        (b) =>
+          b.tokenRef.kind === 'class' && b.tokenRef.className === 'DefaultRepo',
+      )!;
+      const otherBean = result.beans.find(
+        (b) =>
+          b.tokenRef.kind === 'class' && b.tokenRef.className === 'OtherRepo',
+      )!;
+      expect(defaultBean.metadata.primary).toBe(true);
+      expect(otherBean.metadata.primary).toBeUndefined();
     });
   });
 

--- a/packages/transformer/__tests__/plugin-api.test.ts
+++ b/packages/transformer/__tests__/plugin-api.test.ts
@@ -223,6 +223,7 @@ describe('TransformerPlugin API', () => {
         scope: 'singleton',
         eager: false,
         name: undefined,
+        primary: false,
         constructorDeps: [],
         fieldDeps: [],
         factoryKind: 'constructor',

--- a/packages/transformer/__tests__/scanner.test.ts
+++ b/packages/transformer/__tests__/scanner.test.ts
@@ -74,6 +74,46 @@ describe('Scanner', () => {
       expect(result.beans[0].name).toBe('primary');
     });
 
+    it('should detect @Primary flag', () => {
+      const project = createProject({
+        '/src/decorators.ts': `
+          export function Singleton() { return (t: any, c: any) => {} }
+          export function Primary(t: any, c: any) {}
+        `,
+        '/src/DefaultRepo.ts': `
+          import { Singleton, Primary } from './decorators.js'
+
+          @Primary
+          @Singleton()
+          export class DefaultRepo {}
+        `,
+      });
+
+      const result = scan(project);
+
+      expect(result.beans).toHaveLength(1);
+      expect(result.beans[0].primary).toBe(true);
+    });
+
+    it('should default primary to false', () => {
+      const project = createProject({
+        '/src/decorators.ts': `
+          export function Singleton() { return (t: any, c: any) => {} }
+        `,
+        '/src/Repo.ts': `
+          import { Singleton } from './decorators.js'
+
+          @Singleton()
+          export class Repo {}
+        `,
+      });
+
+      const result = scan(project);
+
+      expect(result.beans).toHaveLength(1);
+      expect(result.beans[0].primary).toBe(false);
+    });
+
     it('should detect @Eager flag', () => {
       const project = createProject({
         '/src/decorators.ts': `

--- a/packages/transformer/src/graph-builder.ts
+++ b/packages/transformer/src/graph-builder.ts
@@ -1,4 +1,4 @@
-import type { IRBeanDefinition, TokenRef } from './ir.js';
+import type { IRBeanDefinition, SourceLocation, TokenRef } from './ir.js';
 import type { ResolveResult } from './resolver.js';
 import {
   AmbiguousProviderError,
@@ -105,25 +105,32 @@ function resolveNamedQualifiers(
  * Multiple @Primary beans under the same base token is ambiguous.
  */
 function validatePrimaryUniqueness(beans: IRBeanDefinition[]): void {
-  // Group beans by their base token refs — @Primary matters when
-  // multiple beans share a base type (e.g. both implement CacheProvider)
-  const primaryByBaseToken = new Map<string, IRBeanDefinition[]>();
+  // Group @Primary beans by their token refs — checks both the direct token
+  // (e.g. two @Primary beans with the same class/injection token) and base
+  // token refs (e.g. both implement CacheProvider).
+  const primaryByToken = new Map<string, IRBeanDefinition[]>();
 
   for (const bean of beans) {
     if (!bean.primary) continue;
+
+    // Register under the direct token
+    const directKey = tokenRefKey(bean.tokenRef);
+    const directExisting = primaryByToken.get(directKey) ?? [];
+    directExisting.push(bean);
+    primaryByToken.set(directKey, directExisting);
 
     // Register under each base token
     if (bean.baseTokenRefs) {
       for (const ref of bean.baseTokenRefs) {
         const key = tokenRefKey(ref);
-        const existing = primaryByBaseToken.get(key) ?? [];
+        const existing = primaryByToken.get(key) ?? [];
         existing.push(bean);
-        primaryByBaseToken.set(key, existing);
+        primaryByToken.set(key, existing);
       }
     }
   }
 
-  for (const [_key, primaries] of primaryByBaseToken) {
+  for (const [_key, primaries] of primaryByToken) {
     if (primaries.length > 1) {
       throw new AmbiguousProviderError(
         '@Primary',
@@ -132,7 +139,8 @@ function validatePrimaryUniqueness(beans: IRBeanDefinition[]): void {
             ? b.tokenRef.className
             : b.tokenRef.tokenName,
         ),
-        primaries[1].sourceLocation,
+        primaries[0].sourceLocation,
+        `Also declared @Primary at ${formatLocation(primaries[1].sourceLocation)}`,
       );
     }
   }
@@ -354,4 +362,8 @@ function tokenRefKey(ref: TokenRef): string {
 function tokenRefDisplayName(ref: TokenRef): string {
   if (ref.kind === 'class') return ref.className;
   return ref.tokenName;
+}
+
+function formatLocation(loc: SourceLocation): string {
+  return `${loc.filePath}:${loc.line}:${loc.column}`;
 }

--- a/packages/transformer/src/graph-builder.ts
+++ b/packages/transformer/src/graph-builder.ts
@@ -43,6 +43,9 @@ export function buildGraph(resolveResult: ResolveResult): GraphResult {
   // Build name-based lookup for @Named → @Inject('name') matching
   resolveNamedQualifiers(allBeans, warnings);
 
+  // Validate: at most one @Primary per base token
+  validatePrimaryUniqueness(allBeans);
+
   // Validate: no missing providers (except optional)
   validateProviders(allBeans);
 
@@ -93,6 +96,44 @@ function resolveNamedQualifiers(
           bean.sourceLocation,
         );
       }
+    }
+  }
+}
+
+/**
+ * Validate that at most one bean is marked @Primary per base token.
+ * Multiple @Primary beans under the same base token is ambiguous.
+ */
+function validatePrimaryUniqueness(beans: IRBeanDefinition[]): void {
+  // Group beans by their base token refs — @Primary matters when
+  // multiple beans share a base type (e.g. both implement CacheProvider)
+  const primaryByBaseToken = new Map<string, IRBeanDefinition[]>();
+
+  for (const bean of beans) {
+    if (!bean.primary) continue;
+
+    // Register under each base token
+    if (bean.baseTokenRefs) {
+      for (const ref of bean.baseTokenRefs) {
+        const key = tokenRefKey(ref);
+        const existing = primaryByBaseToken.get(key) ?? [];
+        existing.push(bean);
+        primaryByBaseToken.set(key, existing);
+      }
+    }
+  }
+
+  for (const [_key, primaries] of primaryByBaseToken) {
+    if (primaries.length > 1) {
+      throw new AmbiguousProviderError(
+        '@Primary',
+        primaries.map((b) =>
+          b.tokenRef.kind === 'class'
+            ? b.tokenRef.className
+            : b.tokenRef.tokenName,
+        ),
+        primaries[1].sourceLocation,
+      );
     }
   }
 }

--- a/packages/transformer/src/ir.ts
+++ b/packages/transformer/src/ir.ts
@@ -93,6 +93,8 @@ export interface IRBeanDefinition {
   eager: boolean;
   /** Qualifier name from @Named(). */
   name: string | undefined;
+  /** Whether @Primary marks this bean as the default when multiple match. */
+  primary: boolean;
   /** Constructor parameter dependencies (in order). */
   constructorDeps: IRDependency[];
   /** Accessor field injections (in declaration order). */

--- a/packages/transformer/src/library-beans.ts
+++ b/packages/transformer/src/library-beans.ts
@@ -46,6 +46,7 @@ function serializeBean(bean: IRBeanDefinition): Record<string, unknown> {
     scope: bean.scope,
     eager: bean.eager,
     name: bean.name ?? null,
+    primary: bean.primary,
     constructorDeps: bean.constructorDeps.map((dep) => ({
       tokenRef: serializeTokenRef(dep.tokenRef),
       optional: dep.optional,
@@ -126,6 +127,7 @@ function deserializeBean(raw: Record<string, unknown>): IRBeanDefinition {
     scope: raw.scope as IRBeanDefinition['scope'],
     eager: raw.eager as boolean,
     name: (raw.name as string) ?? undefined,
+    primary: (raw.primary as boolean) ?? false,
     constructorDeps: rawConstructorDeps.map((dep) => ({
       tokenRef: deserializeTokenRef(dep.tokenRef as Record<string, unknown>),
       optional: dep.optional as boolean,

--- a/packages/transformer/src/resolver.ts
+++ b/packages/transformer/src/resolver.ts
@@ -187,6 +187,9 @@ function expandProvides(
       sourceLocation: p.sourceLocation,
     };
 
+    // @Primary on the module class does NOT propagate to provided beans.
+    // Each @Provides bean is an independent definition — mark individual
+    // provided beans with @Primary via a separate decorator if needed.
     return {
       tokenRef,
       scope: 'singleton' as const,

--- a/packages/transformer/src/resolver.ts
+++ b/packages/transformer/src/resolver.ts
@@ -89,6 +89,9 @@ function resolveBean(
   if (scanned.isModule) {
     metadata.isModule = true;
   }
+  if (scanned.primary) {
+    metadata.primary = true;
+  }
   if (scanned.order !== undefined) {
     metadata.order = scanned.order;
   }
@@ -98,6 +101,7 @@ function resolveBean(
     scope: scanned.scope,
     eager: scanned.eager,
     name: scanned.name,
+    primary: scanned.primary,
     constructorDeps,
     fieldDeps,
     factoryKind: 'constructor',
@@ -188,6 +192,7 @@ function expandProvides(
       scope: 'singleton' as const,
       eager: p.eager,
       name: undefined,
+      primary: false,
       constructorDeps: [ownerDep, ...dependencies],
       fieldDeps: [],
       factoryKind: 'provides' as const,

--- a/packages/transformer/src/scanner.ts
+++ b/packages/transformer/src/scanner.ts
@@ -45,6 +45,7 @@ const DECORATOR_NAMES = {
   RequestScoped: 'RequestScoped',
   Value: 'Value',
   Order: 'Order',
+  Primary: 'Primary',
 } as const;
 
 /** A public member of a @RequestScoped bean, used for compile-time scoped proxy generation. */
@@ -82,6 +83,8 @@ export interface ScannedBean {
   methodDecorators: Record<string, IRDecoratorEntry[]>;
   /** Public members for compile-time scoped proxy generation (only for request-scoped beans). */
   publicMembers?: ScannedPublicMember[];
+  /** Whether @Primary is present — marks this bean as the default when multiple match. */
+  primary: boolean;
   /** Execution order from @Order() decorator — lower runs first, default 0. */
   order: number | undefined;
   sourceLocation: SourceLocation;
@@ -346,6 +349,7 @@ function scanBean(
   const className = cls.getName();
   if (!className) return undefined;
   const eager = hasDecorator(decorators, DECORATOR_NAMES.Eager);
+  const primary = hasDecorator(decorators, DECORATOR_NAMES.Primary);
   const name = getNamedValue(decorators);
   const order = getOrderValue(decorators);
   const constructorParams = scanConstructorParams(cls, cache);
@@ -389,6 +393,7 @@ function scanBean(
     valueFields,
     baseClasses,
     isModule,
+    primary,
     provides,
     decorators: scannedDecorators,
     methodDecorators:

--- a/packages/transformer/src/transformer-errors.ts
+++ b/packages/transformer/src/transformer-errors.ts
@@ -86,11 +86,13 @@ export class AmbiguousProviderError extends TransformerError {
     readonly tokenDescription: string,
     readonly candidates: string[],
     sourceLocation: SourceLocation,
+    customHint?: string,
   ) {
     super(
       `Ambiguous provider for "${tokenDescription}": found ${candidates.join(', ')}`,
       sourceLocation,
-      'Use @Named() on the providers and @Inject(name) on the injection point to disambiguate.',
+      customHint ??
+        'Use @Named() on the providers and @Inject(name) on the injection point to disambiguate.',
     );
     this.name = 'AmbiguousProviderError';
   }


### PR DESCRIPTION
## Summary

Adds `@Primary` decorator to `@goodie-ts/core` for bean disambiguation. When multiple beans satisfy the same base token, `@Primary` marks the preferred one — replacing the previous "last wins" semantics.

- New `@Primary()` class decorator in core (no-op at runtime, read at compile time)
- Scanner, IR, resolver, and graph-builder propagate `primary` flag through the pipeline
- `ApplicationContext` prefers `@Primary` beans when resolving by base token
- Compile-time validation: at most one `@Primary` per base token (throws `AmbiguousProviderError`)
- Complements existing `@Named` qualifier

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (973 tests)
- [x] Scanner tests: detects `@Primary` flag, defaults to false
- [x] Graph-builder tests: propagates flag, sets metadata
- [x] ApplicationContext tests: selects @Primary bean, works with base tokens, getAll returns all, falls back to last-wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)