### PR TITLE
feat: add @goodie-ts/security package (#116)

### DIFF
--- a/packages/hono/src/create-router.ts
+++ b/packages/hono/src/create-router.ts
@@ -181,22 +181,15 @@ function resolveServerConfig(
   }
 }
 
-/**
- * Duck-typed interfaces for @goodie-ts/security integration.
- * Avoids a hard dependency — the adapter discovers by convention.
- */
-interface SecurityProviderLike {
-  authenticate(
-    request: HttpContext,
-  ):
-    | Promise<Record<string, unknown> | undefined>
-    | Record<string, unknown>
-    | undefined;
-}
+/** Duck-typed security middleware from @goodie-ts/security. */
+type SecurityMiddlewareFn = (
+  request: HttpContext,
+  next: () => Promise<unknown>,
+) => Promise<unknown>;
 
-interface SecurityContextLike {
-  run<R>(principal: unknown, fn: () => R | Promise<R>): Promise<R>;
-}
+type CreateSecurityMiddlewareFn = (
+  providers: unknown[],
+) => SecurityMiddlewareFn;
 
 /**
  * Discover SecurityProvider beans and build Hono security middleware.
@@ -205,8 +198,9 @@ interface SecurityContextLike {
  * constructor name is 'SecurityProvider'. No direct dependency on
  * @goodie-ts/security — the adapter uses duck typing.
  *
- * If providers are found, also tries to dynamically import SecurityContext
- * from @goodie-ts/security to wrap requests in the security context.
+ * Delegates to `createSecurityMiddleware()` from @goodie-ts/security
+ * (dynamically imported) for the actual auth pipeline. This avoids
+ * duplicating authentication logic.
  */
 function buildSecurityMiddleware(
   ctx: ApplicationContext,
@@ -218,38 +212,31 @@ function buildSecurityMiddleware(
   );
   if (!providerBaseToken) return undefined;
 
-  const providers = ctx.getAll(providerBaseToken) as SecurityProviderLike[];
+  const providers = ctx.getAll(providerBaseToken);
   if (providers.length === 0) return undefined;
 
-  // Lazy-load SecurityContext — resolved on first request
-  let securityContext: SecurityContextLike | undefined | false;
+  // Lazy-load createSecurityMiddleware — resolved on first request
+  let securityMw: SecurityMiddlewareFn | false | undefined;
 
   return async (c: Context, next: Next) => {
-    const request = buildHttpContext(c);
-    let principal: unknown;
-
-    for (const provider of providers) {
-      principal = await provider.authenticate(request);
-      if (principal) break;
-    }
-
-    // Lazy-resolve SecurityContext on first request
-    if (securityContext === undefined) {
+    // Lazy-resolve createSecurityMiddleware on first request
+    if (securityMw === undefined) {
       try {
         // Dynamic import — @goodie-ts/security is an optional peer dep.
         // Use variable to prevent TypeScript from resolving the module.
         const securityPkg = '@goodie-ts/security';
         const mod = await import(/* @vite-ignore */ securityPkg);
-        securityContext =
-          (mod as { SecurityContext?: SecurityContextLike }).SecurityContext ??
-          false;
+        const factory = (
+          mod as { createSecurityMiddleware?: CreateSecurityMiddlewareFn }
+        ).createSecurityMiddleware;
+        securityMw = factory ? factory(providers) : false;
       } catch {
-        securityContext = false;
+        securityMw = false;
       }
     }
 
-    if (securityContext) {
-      await securityContext.run(principal, next);
+    if (securityMw) {
+      await securityMw(buildHttpContext(c), next);
     } else {
       await next();
     }

--- a/packages/hono/src/create-router.ts
+++ b/packages/hono/src/create-router.ts
@@ -1,13 +1,14 @@
-import type { ApplicationContext } from '@goodie-ts/core';
+import type { ApplicationContext, BeanDefinition } from '@goodie-ts/core';
 import {
   type ControllerMetadata,
   ExceptionHandler,
+  type HttpContext,
   type HttpMethod,
   handleException,
   MappedException,
   type ParamMetadata,
 } from '@goodie-ts/http';
-import type { Context } from 'hono';
+import type { Context, Next } from 'hono';
 import { Hono } from 'hono';
 
 import {
@@ -49,6 +50,12 @@ export function createHonoRouter(ctx: ApplicationContext): Hono {
   // CORS middleware from ServerConfig
   if (serverConfig && hasCorsConfig(serverConfig.cors)) {
     router.use('*', corsMiddleware(serverConfig.cors));
+  }
+
+  // Security middleware — discover SecurityProvider beans via convention
+  const securityMiddleware = buildSecurityMiddleware(ctx, definitions);
+  if (securityMiddleware) {
+    router.use('*', securityMiddleware);
   }
 
   // Wire controllers
@@ -172,4 +179,95 @@ function resolveServerConfig(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Duck-typed interfaces for @goodie-ts/security integration.
+ * Avoids a hard dependency — the adapter discovers by convention.
+ */
+interface SecurityProviderLike {
+  authenticate(
+    request: HttpContext,
+  ):
+    | Promise<Record<string, unknown> | undefined>
+    | Record<string, unknown>
+    | undefined;
+}
+
+interface SecurityContextLike {
+  run<R>(principal: unknown, fn: () => R | Promise<R>): Promise<R>;
+}
+
+/**
+ * Discover SecurityProvider beans and build Hono security middleware.
+ *
+ * Uses convention-based discovery: finds beans with baseTokens whose
+ * constructor name is 'SecurityProvider'. No direct dependency on
+ * @goodie-ts/security — the adapter uses duck typing.
+ *
+ * If providers are found, also tries to dynamically import SecurityContext
+ * from @goodie-ts/security to wrap requests in the security context.
+ */
+function buildSecurityMiddleware(
+  ctx: ApplicationContext,
+  definitions: readonly BeanDefinition[],
+): ((c: Context, next: Next) => Promise<Response | void>) | undefined {
+  const providerBaseToken = findBaseTokenByName(
+    definitions,
+    'SecurityProvider',
+  );
+  if (!providerBaseToken) return undefined;
+
+  const providers = ctx.getAll(providerBaseToken) as SecurityProviderLike[];
+  if (providers.length === 0) return undefined;
+
+  // Lazy-load SecurityContext — resolved on first request
+  let securityContext: SecurityContextLike | undefined | false;
+
+  return async (c: Context, next: Next) => {
+    const request = buildHttpContext(c);
+    let principal: unknown;
+
+    for (const provider of providers) {
+      principal = await provider.authenticate(request);
+      if (principal) break;
+    }
+
+    // Lazy-resolve SecurityContext on first request
+    if (securityContext === undefined) {
+      try {
+        // Dynamic import — @goodie-ts/security is an optional peer dep.
+        // Use variable to prevent TypeScript from resolving the module.
+        const securityPkg = '@goodie-ts/security';
+        const mod = await import(/* @vite-ignore */ securityPkg);
+        securityContext =
+          (mod as { SecurityContext?: SecurityContextLike }).SecurityContext ??
+          false;
+      } catch {
+        securityContext = false;
+      }
+    }
+
+    if (securityContext) {
+      await securityContext.run(principal, next);
+    } else {
+      await next();
+    }
+  };
+}
+
+function findBaseTokenByName(
+  definitions: readonly BeanDefinition[],
+  className: string,
+): BeanDefinition['token'] | undefined {
+  for (const def of definitions) {
+    if (def.baseTokens) {
+      for (const baseToken of def.baseTokens) {
+        if (typeof baseToken === 'function' && baseToken.name === className) {
+          return baseToken as BeanDefinition['token'];
+        }
+      }
+    }
+  }
+  return undefined;
 }

--- a/packages/security/__tests__/security-context.test.ts
+++ b/packages/security/__tests__/security-context.test.ts
@@ -64,4 +64,22 @@ describe('SecurityContext', () => {
       expect(SecurityContext.current()).toBeUndefined();
     });
   });
+
+  it('isActive() returns true inside security context even when unauthenticated', async () => {
+    await SecurityContext.run(undefined, () => {
+      expect(SecurityContext.isActive()).toBe(true);
+      expect(SecurityContext.current()).toBeUndefined();
+    });
+  });
+
+  it('isActive() returns true when authenticated', async () => {
+    const principal: Principal = {
+      name: 'alice',
+      roles: [],
+      attributes: {},
+    };
+    await SecurityContext.run(principal, () => {
+      expect(SecurityContext.isActive()).toBe(true);
+    });
+  });
 });

--- a/packages/security/__tests__/security-context.test.ts
+++ b/packages/security/__tests__/security-context.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { Principal } from '../src/principal.js';
+import { SecurityContext } from '../src/security-context.js';
+
+describe('SecurityContext', () => {
+  it('returns undefined when no context is set', () => {
+    expect(SecurityContext.current()).toBeUndefined();
+  });
+
+  it('stores and retrieves principal within run()', async () => {
+    const principal: Principal = {
+      name: 'alice',
+      roles: ['USER'],
+      attributes: { email: 'alice@example.com' },
+    };
+
+    await SecurityContext.run(principal, () => {
+      const current = SecurityContext.current();
+      expect(current).toBe(principal);
+      expect(current!.name).toBe('alice');
+      expect(current!.roles).toEqual(['USER']);
+    });
+  });
+
+  it('restores undefined after run() completes', async () => {
+    const principal: Principal = {
+      name: 'bob',
+      roles: [],
+      attributes: {},
+    };
+
+    await SecurityContext.run(principal, () => {
+      expect(SecurityContext.current()).toBe(principal);
+    });
+
+    expect(SecurityContext.current()).toBeUndefined();
+  });
+
+  it('supports nested contexts', async () => {
+    const outer: Principal = {
+      name: 'outer',
+      roles: [],
+      attributes: {},
+    };
+    const inner: Principal = {
+      name: 'inner',
+      roles: [],
+      attributes: {},
+    };
+
+    await SecurityContext.run(outer, async () => {
+      expect(SecurityContext.current()!.name).toBe('outer');
+
+      await SecurityContext.run(inner, () => {
+        expect(SecurityContext.current()!.name).toBe('inner');
+      });
+
+      expect(SecurityContext.current()!.name).toBe('outer');
+    });
+  });
+
+  it('supports unauthenticated run (undefined principal)', async () => {
+    await SecurityContext.run(undefined, () => {
+      expect(SecurityContext.current()).toBeUndefined();
+    });
+  });
+});

--- a/packages/security/__tests__/security-exception-handler.test.ts
+++ b/packages/security/__tests__/security-exception-handler.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { ForbiddenError, UnauthorizedError } from '../src/errors.js';
+import { SecurityExceptionHandler } from '../src/security-exception-handler.js';
+
+describe('SecurityExceptionHandler', () => {
+  const handler = new SecurityExceptionHandler();
+
+  it('maps UnauthorizedError to 401', () => {
+    const response = handler.handle(new UnauthorizedError());
+    expect(response).toBeDefined();
+    expect(response!.status).toBe(401);
+    expect(response!.body).toEqual({ message: 'Unauthorized' });
+  });
+
+  it('maps ForbiddenError to 403', () => {
+    const response = handler.handle(
+      new ForbiddenError('Not enough privileges'),
+    );
+    expect(response).toBeDefined();
+    expect(response!.status).toBe(403);
+    expect(response!.body).toEqual({ message: 'Not enough privileges' });
+  });
+
+  it('returns undefined for unknown errors', () => {
+    const response = handler.handle(new Error('something else'));
+    expect(response).toBeUndefined();
+  });
+
+  it('returns undefined for non-Error values', () => {
+    const response = handler.handle('string error');
+    expect(response).toBeUndefined();
+  });
+});

--- a/packages/security/__tests__/security-interceptor.test.ts
+++ b/packages/security/__tests__/security-interceptor.test.ts
@@ -81,6 +81,20 @@ describe('SecurityInterceptor', () => {
     });
   });
 
+  it('skips auth for @Anonymous methods (anonymous: true metadata)', () => {
+    // @Anonymous methods should bypass all auth — no principal needed
+    const ctx = makeCtx({ anonymous: true });
+    const result = interceptor.intercept(ctx);
+    expect(result).toBe('ok');
+  });
+
+  it('skips auth for @Anonymous even when roles are set', () => {
+    // Class-level @Secured('ADMIN') + method-level @Anonymous → anonymous wins
+    const ctx = makeCtx({ roles: 'ADMIN', anonymous: true });
+    const result = interceptor.intercept(ctx);
+    expect(result).toBe('ok');
+  });
+
   it('calls proceed() when authorized', async () => {
     const principal: Principal = {
       name: 'admin',

--- a/packages/security/__tests__/security-interceptor.test.ts
+++ b/packages/security/__tests__/security-interceptor.test.ts
@@ -1,0 +1,109 @@
+import type { InvocationContext } from '@goodie-ts/core';
+import { describe, expect, it } from 'vitest';
+import { ForbiddenError, UnauthorizedError } from '../src/errors.js';
+import type { Principal } from '../src/principal.js';
+import { SecurityContext } from '../src/security-context.js';
+import { SecurityInterceptor } from '../src/security-interceptor.js';
+
+function makeCtx(
+  metadata?: Record<string, unknown>,
+  returnValue: unknown = 'ok',
+): InvocationContext {
+  return {
+    className: 'TestService',
+    methodName: 'doSomething',
+    args: [],
+    target: {},
+    proceed: () => returnValue,
+    metadata,
+  };
+}
+
+describe('SecurityInterceptor', () => {
+  const interceptor = new SecurityInterceptor();
+
+  it('throws UnauthorizedError when no principal is set', async () => {
+    const ctx = makeCtx();
+    // No SecurityContext.run() — principal is undefined
+    expect(() => interceptor.intercept(ctx)).toThrow(UnauthorizedError);
+  });
+
+  it('allows access when principal exists and no roles required', async () => {
+    const principal: Principal = {
+      name: 'alice',
+      roles: [],
+      attributes: {},
+    };
+
+    const result = await SecurityContext.run(principal, () =>
+      interceptor.intercept(makeCtx()),
+    );
+    expect(result).toBe('ok');
+  });
+
+  it('allows access when principal has required role', async () => {
+    const principal: Principal = {
+      name: 'alice',
+      roles: ['ADMIN'],
+      attributes: {},
+    };
+
+    const result = await SecurityContext.run(principal, () =>
+      interceptor.intercept(makeCtx({ roles: 'ADMIN' })),
+    );
+    expect(result).toBe('ok');
+  });
+
+  it('allows access when principal has one of required roles', async () => {
+    const principal: Principal = {
+      name: 'alice',
+      roles: ['EDITOR'],
+      attributes: {},
+    };
+
+    const result = await SecurityContext.run(principal, () =>
+      interceptor.intercept(makeCtx({ roles: ['ADMIN', 'EDITOR'] })),
+    );
+    expect(result).toBe('ok');
+  });
+
+  it('throws ForbiddenError when principal lacks required role', async () => {
+    const principal: Principal = {
+      name: 'alice',
+      roles: ['USER'],
+      attributes: {},
+    };
+
+    await SecurityContext.run(principal, () => {
+      expect(() => interceptor.intercept(makeCtx({ roles: 'ADMIN' }))).toThrow(
+        ForbiddenError,
+      );
+    });
+  });
+
+  it('calls proceed() when authorized', async () => {
+    const principal: Principal = {
+      name: 'admin',
+      roles: ['ADMIN'],
+      attributes: {},
+    };
+    let called = false;
+    const ctx: InvocationContext = {
+      className: 'Svc',
+      methodName: 'op',
+      args: [],
+      target: {},
+      proceed: () => {
+        called = true;
+        return 42;
+      },
+      metadata: { roles: 'ADMIN' },
+    };
+
+    const result = await SecurityContext.run(principal, () =>
+      interceptor.intercept(ctx),
+    );
+    expect(called).toBe(true);
+    expect(result).toBe(42);
+  });
+});

--- a/packages/security/__tests__/security-middleware.test.ts
+++ b/packages/security/__tests__/security-middleware.test.ts
@@ -1,0 +1,126 @@
+import { HttpContext } from '@goodie-ts/http';
+import { describe, expect, it } from 'vitest';
+import type { Principal } from '../src/principal.js';
+import { SecurityContext } from '../src/security-context.js';
+import { createSecurityMiddleware } from '../src/security-middleware.js';
+import type { SecurityProvider } from '../src/security-provider.js';
+
+function makeRequest(headers: Record<string, string> = {}): HttpContext {
+  return new HttpContext({
+    headers: new Headers(headers),
+  });
+}
+
+describe('createSecurityMiddleware', () => {
+  it('sets principal when provider authenticates', async () => {
+    const principal: Principal = {
+      name: 'alice',
+      roles: ['USER'],
+      attributes: {},
+    };
+
+    const provider: SecurityProvider = {
+      authenticate: () => principal,
+    };
+
+    const middleware = createSecurityMiddleware([provider]);
+    let captured: Principal | undefined;
+
+    await middleware(makeRequest(), async () => {
+      captured = SecurityContext.current();
+    });
+
+    expect(captured).toBe(principal);
+  });
+
+  it('sets undefined when no provider authenticates', async () => {
+    const provider: SecurityProvider = {
+      authenticate: () => undefined,
+    };
+
+    const middleware = createSecurityMiddleware([provider]);
+    let captured: Principal | undefined = {
+      name: 'should-be-replaced',
+      roles: [],
+      attributes: {},
+    };
+
+    await middleware(makeRequest(), async () => {
+      captured = SecurityContext.current();
+    });
+
+    expect(captured).toBeUndefined();
+  });
+
+  it('stops at first successful provider', async () => {
+    const principal1: Principal = {
+      name: 'from-provider-1',
+      roles: [],
+      attributes: {},
+    };
+
+    let provider2Called = false;
+    const providers: SecurityProvider[] = [
+      { authenticate: () => principal1 },
+      {
+        authenticate: () => {
+          provider2Called = true;
+          return { name: 'from-provider-2', roles: [], attributes: {} };
+        },
+      },
+    ];
+
+    const middleware = createSecurityMiddleware(providers);
+    let captured: Principal | undefined;
+
+    await middleware(makeRequest(), async () => {
+      captured = SecurityContext.current();
+    });
+
+    expect(captured!.name).toBe('from-provider-1');
+    expect(provider2Called).toBe(false);
+  });
+
+  it('passes HttpContext to providers', async () => {
+    let receivedHeaders: Headers | undefined;
+
+    const provider: SecurityProvider = {
+      authenticate: (request) => {
+        receivedHeaders = request.headers;
+        return undefined;
+      },
+    };
+
+    const middleware = createSecurityMiddleware([provider]);
+    await middleware(
+      makeRequest({ Authorization: 'Bearer token123' }),
+      async () => {},
+    );
+
+    expect(receivedHeaders!.get('Authorization')).toBe('Bearer token123');
+  });
+
+  it('supports async providers', async () => {
+    const principal: Principal = {
+      name: 'async-user',
+      roles: [],
+      attributes: {},
+    };
+
+    const provider: SecurityProvider = {
+      authenticate: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return principal;
+      },
+    };
+
+    const middleware = createSecurityMiddleware([provider]);
+    let captured: Principal | undefined;
+
+    await middleware(makeRequest(), async () => {
+      captured = SecurityContext.current();
+    });
+
+    expect(captured!.name).toBe('async-user');
+  });
+});

--- a/packages/security/__tests__/security-plugin.test.ts
+++ b/packages/security/__tests__/security-plugin.test.ts
@@ -130,6 +130,29 @@ describe('Security Plugin', () => {
     });
   });
 
+  it('records @Anonymous on non-@Secured class (creates security metadata)', () => {
+    const project = createProject({
+      '/src/decorators.ts': decoratorsFile,
+      '/src/OpenService.ts': `
+        import { Singleton, Anonymous } from './decorators.js'
+
+        @Singleton()
+        export class OpenService {
+          @Anonymous()
+          publicMethod() {}
+        }
+      `,
+    });
+
+    const result = scan(project, [createSecurityPlugin()]);
+
+    const security = getMetadata(result, 'OpenService');
+    expect(security?.security).toEqual({
+      classRoles: [],
+      anonymousMethods: ['publicMethod'],
+    });
+  });
+
   it('does not set metadata on non-@Secured classes', () => {
     const project = createProject({
       '/src/decorators.ts': decoratorsFile,

--- a/packages/security/__tests__/security-plugin.test.ts
+++ b/packages/security/__tests__/security-plugin.test.ts
@@ -1,0 +1,151 @@
+import { type ScanResult, scan } from '@goodie-ts/transformer';
+import { Project } from 'ts-morph';
+import { describe, expect, it } from 'vitest';
+import createSecurityPlugin from '../src/plugin.js';
+
+/** Find plugin metadata by class name (keys are "filePath:className"). */
+function getMetadata(
+  result: ScanResult,
+  className: string,
+): Record<string, unknown> | undefined {
+  if (!result.pluginMetadata) return undefined;
+  for (const [key, value] of result.pluginMetadata) {
+    if (key.endsWith(`:${className}`)) return value;
+  }
+  return undefined;
+}
+
+function createProject(files: Record<string, string>): Project {
+  const project = new Project({ useInMemoryFileSystem: true });
+  for (const [path, content] of Object.entries(files)) {
+    project.createSourceFile(path, content);
+  }
+  return project;
+}
+
+const decoratorsFile = `
+  export function Singleton() { return (t: any, c: any) => {} }
+  export function Secured(roles?: string | string[]) { return (t: any, c: any) => {} }
+  export function Anonymous() { return (t: any, c: any) => {} }
+`;
+
+describe('Security Plugin', () => {
+  it('detects @Secured on class and stores classRoles', () => {
+    const project = createProject({
+      '/src/decorators.ts': decoratorsFile,
+      '/src/AdminService.ts': `
+        import { Singleton, Secured } from './decorators.js'
+
+        @Secured('ADMIN')
+        @Singleton()
+        export class AdminService {
+          doStuff() {}
+        }
+      `,
+    });
+
+    const result = scan(project, [createSecurityPlugin()]);
+
+    const bean = result.beans.find(
+      (b) => b.classTokenRef.className === 'AdminService',
+    )!;
+    expect(bean).toBeDefined();
+
+    const security = getMetadata(result, 'AdminService');
+    expect(security?.security).toEqual({
+      classRoles: ['ADMIN'],
+      anonymousMethods: [],
+    });
+  });
+
+  it('detects @Secured with no roles (auth-only)', () => {
+    const project = createProject({
+      '/src/decorators.ts': decoratorsFile,
+      '/src/ProtectedService.ts': `
+        import { Singleton, Secured } from './decorators.js'
+
+        @Secured()
+        @Singleton()
+        export class ProtectedService {
+          doStuff() {}
+        }
+      `,
+    });
+
+    const result = scan(project, [createSecurityPlugin()]);
+
+    const security = getMetadata(result, 'ProtectedService');
+    expect(security?.security).toEqual({
+      classRoles: [],
+      anonymousMethods: [],
+    });
+  });
+
+  it('detects @Secured with array of roles', () => {
+    const project = createProject({
+      '/src/decorators.ts': decoratorsFile,
+      '/src/MultiRoleService.ts': `
+        import { Singleton, Secured } from './decorators.js'
+
+        @Secured(['ADMIN', 'EDITOR'])
+        @Singleton()
+        export class MultiRoleService {
+          doStuff() {}
+        }
+      `,
+    });
+
+    const result = scan(project, [createSecurityPlugin()]);
+
+    const security = getMetadata(result, 'MultiRoleService');
+    expect(security?.security).toEqual({
+      classRoles: ['ADMIN', 'EDITOR'],
+      anonymousMethods: [],
+    });
+  });
+
+  it('detects @Anonymous on methods', () => {
+    const project = createProject({
+      '/src/decorators.ts': decoratorsFile,
+      '/src/MixedService.ts': `
+        import { Singleton, Secured, Anonymous } from './decorators.js'
+
+        @Secured('ADMIN')
+        @Singleton()
+        export class MixedService {
+          protectedMethod() {}
+
+          @Anonymous()
+          publicMethod() {}
+        }
+      `,
+    });
+
+    const result = scan(project, [createSecurityPlugin()]);
+
+    const security = getMetadata(result, 'MixedService');
+    expect(security?.security).toEqual({
+      classRoles: ['ADMIN'],
+      anonymousMethods: ['publicMethod'],
+    });
+  });
+
+  it('does not set metadata on non-@Secured classes', () => {
+    const project = createProject({
+      '/src/decorators.ts': decoratorsFile,
+      '/src/PlainService.ts': `
+        import { Singleton } from './decorators.js'
+
+        @Singleton()
+        export class PlainService {
+          doStuff() {}
+        }
+      `,
+    });
+
+    const result = scan(project, [createSecurityPlugin()]);
+
+    const metadata = getMetadata(result, 'PlainService');
+    expect(metadata?.security).toBeUndefined();
+  });
+});

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@goodie-ts/security",
+  "version": "1.0.0",
+  "description": "Authentication and authorization for goodie-ts",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GOOD-Code-ApS/goodie.git",
+    "directory": "packages/security"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "goodie": {
+    "plugin": "dist/plugin.js",
+    "beans": "dist/beans.json"
+  },
+  "scripts": {
+    "build": "tsc && goodie generate --mode library",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "files": [
+    "dist"
+  ],
+  "peerDependencies": {
+    "@goodie-ts/core": ">=1.0.0",
+    "@goodie-ts/http": ">=1.0.0"
+  },
+  "devDependencies": {
+    "@goodie-ts/cli": "workspace:*",
+    "@goodie-ts/core": "workspace:*",
+    "@goodie-ts/http": "workspace:*",
+    "@goodie-ts/transformer": "workspace:*",
+    "@types/node": "^22.0.0",
+    "ts-morph": "^24.0.0"
+  }
+}

--- a/packages/security/src/decorators/anonymous.ts
+++ b/packages/security/src/decorators/anonymous.ts
@@ -1,0 +1,27 @@
+/**
+ * @Anonymous() — exempts a method from class-level @Secured.
+ *
+ * Only meaningful when a class has @Secured at class level.
+ * Methods decorated with @Anonymous() skip authorization checks.
+ *
+ * No-op at runtime — the security plugin captures this at compile time
+ * and stores it in metadata.security.anonymousMethods.
+ *
+ * @example
+ * @Secured('ADMIN')
+ * @Singleton()
+ * class AdminService {
+ *   // Requires ADMIN role
+ *   deleteUser(id: string) { ... }
+ *
+ *   // Open to all — no auth required
+ *   @Anonymous()
+ *   healthCheck() { ... }
+ * }
+ */
+export function Anonymous(): (
+  target: Function,
+  context: ClassMethodDecoratorContext,
+) => void {
+  return () => {};
+}

--- a/packages/security/src/decorators/secured.ts
+++ b/packages/security/src/decorators/secured.ts
@@ -12,7 +12,7 @@ import type { SecurityInterceptor } from '../security-interceptor.js';
  * @Secured('ADMIN')             // requires ADMIN role
  * @Secured(['ADMIN', 'EDITOR']) // requires ADMIN or EDITOR
  *
- * Order `-95` ensures security runs early — after validation (-90) but before
+ * Order `-95` ensures security runs early — before validation (-90) and before
  * business logic interceptors like @Log (0), @Cacheable (0), etc.
  */
 export const Secured = createAopDecorator<{

--- a/packages/security/src/decorators/secured.ts
+++ b/packages/security/src/decorators/secured.ts
@@ -1,0 +1,23 @@
+import { createAopDecorator } from '@goodie-ts/core';
+import type { SecurityInterceptor } from '../security-interceptor.js';
+
+/**
+ * @Secured — restricts access to authenticated principals with the required roles.
+ *
+ * Can be applied at class level (all methods require auth) or method level.
+ * When applied at class level, individual methods can be exempted with @Anonymous.
+ *
+ * @example
+ * @Secured()                    // any authenticated user
+ * @Secured('ADMIN')             // requires ADMIN role
+ * @Secured(['ADMIN', 'EDITOR']) // requires ADMIN or EDITOR
+ *
+ * Order `-95` ensures security runs early — after validation (-90) but before
+ * business logic interceptors like @Log (0), @Cacheable (0), etc.
+ */
+export const Secured = createAopDecorator<{
+  interceptor: SecurityInterceptor;
+  order: -95;
+  argMapping: ['roles'];
+  args: [roles?: string | string[]];
+}>();

--- a/packages/security/src/errors.ts
+++ b/packages/security/src/errors.ts
@@ -1,0 +1,21 @@
+/**
+ * Thrown when a request lacks valid authentication credentials.
+ * The SecurityExceptionHandler maps this to HTTP 401.
+ */
+export class UnauthorizedError extends Error {
+  constructor(message = 'Unauthorized') {
+    super(message);
+    this.name = 'UnauthorizedError';
+  }
+}
+
+/**
+ * Thrown when an authenticated principal lacks the required roles.
+ * The SecurityExceptionHandler maps this to HTTP 403.
+ */
+export class ForbiddenError extends Error {
+  constructor(message = 'Forbidden') {
+    super(message);
+    this.name = 'ForbiddenError';
+  }
+}

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -1,0 +1,24 @@
+// Decorators
+export { Anonymous } from './decorators/anonymous.js';
+export { Secured } from './decorators/secured.js';
+
+// Errors
+export { ForbiddenError, UnauthorizedError } from './errors.js';
+
+// Types
+export type { Principal } from './principal.js';
+
+// Context
+export { SecurityContext } from './security-context.js';
+
+// Exception handler
+export { SecurityExceptionHandler } from './security-exception-handler.js';
+
+// Interceptor
+export { SecurityInterceptor } from './security-interceptor.js';
+
+// Middleware
+export { createSecurityMiddleware } from './security-middleware.js';
+
+// Provider
+export { SECURITY_PROVIDER, SecurityProvider } from './security-provider.js';

--- a/packages/security/src/plugin.ts
+++ b/packages/security/src/plugin.ts
@@ -1,0 +1,83 @@
+import type {
+  ClassVisitorContext,
+  MethodVisitorContext,
+  TransformerPlugin,
+} from '@goodie-ts/transformer';
+
+/**
+ * Security transformer plugin (scan-phase only).
+ *
+ * Scans @Secured on classes and methods, and @Anonymous on methods.
+ * Stores security metadata on the bean definition for runtime use
+ * by the SecurityInterceptor.
+ *
+ * Auto-discovered via `"goodie": { "plugin": "dist/plugin.js" }` in package.json.
+ */
+export default function createSecurityPlugin(): TransformerPlugin {
+  return {
+    name: 'security',
+
+    visitClass(ctx: ClassVisitorContext): void {
+      const hasSecured = ctx.decorators.some((d) => d.name === 'Secured');
+      if (!hasSecured) return;
+
+      // Extract roles from the AST — @Secured('ADMIN') or @Secured(['ADMIN', 'USER'])
+      const securedDec = ctx.classDeclaration
+        .getDecorators()
+        .find((d) => d.getName() === 'Secured');
+      const classRoles = securedDec
+        ? extractRolesFromArgs(securedDec.getArguments())
+        : [];
+
+      ctx.metadata.security = {
+        classRoles,
+        anonymousMethods: [] as string[],
+      };
+    },
+
+    visitMethod(ctx: MethodVisitorContext): void {
+      const isAnonymous = ctx.decorators.some((d) => d.name === 'Anonymous');
+      if (isAnonymous) {
+        const security = (ctx.classMetadata.security ?? {
+          classRoles: [],
+          anonymousMethods: [],
+        }) as { classRoles: string[]; anonymousMethods: string[] };
+        security.anonymousMethods.push(ctx.methodName);
+        ctx.classMetadata.security = security;
+      }
+    },
+  };
+}
+
+function extractRolesFromArgs(args: { getText(): string }[]): string[] {
+  if (args.length === 0) return [];
+  const text = args[0].getText().trim();
+
+  // @Secured('ADMIN') — single string
+  if (
+    (text.startsWith("'") && text.endsWith("'")) ||
+    (text.startsWith('"') && text.endsWith('"'))
+  ) {
+    return [text.slice(1, -1)];
+  }
+
+  // @Secured(['ADMIN', 'USER']) — array literal
+  if (text.startsWith('[') && text.endsWith(']')) {
+    const inner = text.slice(1, -1);
+    return inner
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .map((s) => {
+        if (
+          (s.startsWith("'") && s.endsWith("'")) ||
+          (s.startsWith('"') && s.endsWith('"'))
+        ) {
+          return s.slice(1, -1);
+        }
+        return s;
+      });
+  }
+
+  return [];
+}

--- a/packages/security/src/plugin.ts
+++ b/packages/security/src/plugin.ts
@@ -1,15 +1,17 @@
 import type {
   ClassVisitorContext,
+  IRBeanDefinition,
   MethodVisitorContext,
   TransformerPlugin,
 } from '@goodie-ts/transformer';
+import { Node, SyntaxKind } from 'ts-morph';
 
 /**
- * Security transformer plugin (scan-phase only).
+ * Security transformer plugin.
  *
- * Scans @Secured on classes and methods, and @Anonymous on methods.
- * Stores security metadata on the bean definition for runtime use
- * by the SecurityInterceptor.
+ * Scan phase: detects @Secured on classes and @Anonymous on methods.
+ * afterResolve: marks anonymous methods in the AOP interceptor metadata
+ * so the SecurityInterceptor can skip auth for those methods.
  *
  * Auto-discovered via `"goodie": { "plugin": "dist/plugin.js" }` in package.json.
  */
@@ -21,12 +23,12 @@ export default function createSecurityPlugin(): TransformerPlugin {
       const hasSecured = ctx.decorators.some((d) => d.name === 'Secured');
       if (!hasSecured) return;
 
-      // Extract roles from the AST — @Secured('ADMIN') or @Secured(['ADMIN', 'USER'])
+      // Extract roles from AST using ts-morph node traversal
       const securedDec = ctx.classDeclaration
         .getDecorators()
         .find((d) => d.getName() === 'Secured');
       const classRoles = securedDec
-        ? extractRolesFromArgs(securedDec.getArguments())
+        ? extractRolesFromDecorator(securedDec.getArguments())
         : [];
 
       ctx.metadata.security = {
@@ -46,37 +48,70 @@ export default function createSecurityPlugin(): TransformerPlugin {
         ctx.classMetadata.security = security;
       }
     },
+
+    afterResolve(beans: IRBeanDefinition[]): IRBeanDefinition[] {
+      // Mark anonymous methods in the AOP interceptor metadata so
+      // SecurityInterceptor can skip auth for @Anonymous methods.
+      for (const bean of beans) {
+        const security = bean.metadata.security as
+          | { classRoles: string[]; anonymousMethods: string[] }
+          | undefined;
+        if (!security || security.anonymousMethods.length === 0) continue;
+
+        const interceptedMethods = bean.metadata.interceptedMethods as
+          | Array<{
+              methodName: string;
+              interceptors: Array<{
+                className: string;
+                importPath: string;
+                adviceType: string;
+                order: number;
+                metadata?: Record<string, unknown>;
+              }>;
+            }>
+          | undefined;
+        if (!interceptedMethods) continue;
+
+        const anonymousSet = new Set(security.anonymousMethods);
+        for (const method of interceptedMethods) {
+          if (!anonymousSet.has(method.methodName)) continue;
+          for (const interceptor of method.interceptors) {
+            if (interceptor.className === 'SecurityInterceptor') {
+              interceptor.metadata = {
+                ...interceptor.metadata,
+                anonymous: true,
+              };
+            }
+          }
+        }
+      }
+
+      return beans;
+    },
   };
 }
 
-function extractRolesFromArgs(args: { getText(): string }[]): string[] {
+/**
+ * Extract roles from decorator arguments using ts-morph AST traversal.
+ * Handles @Secured('ADMIN') and @Secured(['ADMIN', 'USER']).
+ */
+function extractRolesFromDecorator(args: Node[]): string[] {
   if (args.length === 0) return [];
-  const text = args[0].getText().trim();
+  const arg = args[0];
 
-  // @Secured('ADMIN') — single string
-  if (
-    (text.startsWith("'") && text.endsWith("'")) ||
-    (text.startsWith('"') && text.endsWith('"'))
-  ) {
-    return [text.slice(1, -1)];
+  // @Secured('ADMIN') — single string literal
+  if (Node.isStringLiteral(arg)) {
+    return [arg.getLiteralValue()];
   }
 
   // @Secured(['ADMIN', 'USER']) — array literal
-  if (text.startsWith('[') && text.endsWith(']')) {
-    const inner = text.slice(1, -1);
-    return inner
-      .split(',')
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0)
-      .map((s) => {
-        if (
-          (s.startsWith("'") && s.endsWith("'")) ||
-          (s.startsWith('"') && s.endsWith('"'))
-        ) {
-          return s.slice(1, -1);
-        }
-        return s;
-      });
+  if (Node.isArrayLiteralExpression(arg)) {
+    return arg
+      .getElements()
+      .filter((el): el is import('ts-morph').StringLiteral =>
+        Node.isStringLiteral(el),
+      )
+      .map((el) => el.getLiteralValue());
   }
 
   return [];

--- a/packages/security/src/principal.ts
+++ b/packages/security/src/principal.ts
@@ -1,0 +1,14 @@
+/**
+ * Represents an authenticated identity.
+ *
+ * Adapters set this on the SecurityContext after successful authentication.
+ * Application code reads it via `SecurityContext.current()`.
+ */
+export interface Principal {
+  /** The identity name (e.g. username, email, subject ID). */
+  name: string;
+  /** Roles granted to this principal (e.g. 'ADMIN', 'USER'). */
+  roles: string[];
+  /** Arbitrary attributes (claims, metadata). */
+  attributes: Record<string, unknown>;
+}

--- a/packages/security/src/security-context.ts
+++ b/packages/security/src/security-context.ts
@@ -1,14 +1,23 @@
 import type { Principal } from './principal.js';
 
 /**
+ * Sentinel wrapper so we can distinguish "not inside a security context"
+ * (getStore() === undefined) from "inside context but unauthenticated"
+ * (getStore() === { principal: undefined }).
+ */
+interface SecurityStore {
+  principal: Principal | undefined;
+}
+
+/**
  * Lazy-loaded AsyncLocalStorage for the security context.
  * Same pattern as RequestScopeManager in @goodie-ts/core.
  */
 let storage:
-  | import('node:async_hooks').AsyncLocalStorage<Principal | undefined>
+  | import('node:async_hooks').AsyncLocalStorage<SecurityStore>
   | undefined;
 let storagePromise:
-  | Promise<import('node:async_hooks').AsyncLocalStorage<Principal | undefined>>
+  | Promise<import('node:async_hooks').AsyncLocalStorage<SecurityStore>>
   | undefined;
 
 async function getStorage() {
@@ -16,7 +25,7 @@ async function getStorage() {
   if (!storagePromise) {
     storagePromise = import('node:async_hooks')
       .then(({ AsyncLocalStorage }) => {
-        storage = new AsyncLocalStorage<Principal | undefined>();
+        storage = new AsyncLocalStorage<SecurityStore>();
         return storage;
       })
       .catch(() => {
@@ -47,7 +56,7 @@ export const SecurityContext = {
     fn: () => R | Promise<R>,
   ): Promise<R> {
     const als = await getStorage();
-    return als.run(principal, fn);
+    return als.run({ principal }, fn);
   },
 
   /**
@@ -55,11 +64,13 @@ export const SecurityContext = {
    * Returns undefined if not authenticated or not inside a security context.
    */
   current(): Principal | undefined {
-    return storage?.getStore();
+    return storage?.getStore()?.principal;
   },
 
   /**
    * Check if code is running inside a security context.
+   * Returns true even for unauthenticated requests (principal is undefined)
+   * as long as the security middleware is active.
    */
   isActive(): boolean {
     return storage?.getStore() !== undefined;

--- a/packages/security/src/security-context.ts
+++ b/packages/security/src/security-context.ts
@@ -1,0 +1,67 @@
+import type { Principal } from './principal.js';
+
+/**
+ * Lazy-loaded AsyncLocalStorage for the security context.
+ * Same pattern as RequestScopeManager in @goodie-ts/core.
+ */
+let storage:
+  | import('node:async_hooks').AsyncLocalStorage<Principal | undefined>
+  | undefined;
+let storagePromise:
+  | Promise<import('node:async_hooks').AsyncLocalStorage<Principal | undefined>>
+  | undefined;
+
+async function getStorage() {
+  if (storage) return storage;
+  if (!storagePromise) {
+    storagePromise = import('node:async_hooks')
+      .then(({ AsyncLocalStorage }) => {
+        storage = new AsyncLocalStorage<Principal | undefined>();
+        return storage;
+      })
+      .catch(() => {
+        storagePromise = undefined;
+        throw new Error(
+          'SecurityContext requires AsyncLocalStorage from node:async_hooks. ' +
+            'On Cloudflare Workers, enable the nodejs_compat compatibility flag.',
+        );
+      });
+  }
+  return storagePromise;
+}
+
+/**
+ * Security context backed by AsyncLocalStorage.
+ *
+ * Stores the authenticated `Principal` for the current request.
+ * Adapters call `SecurityContext.run()` in middleware after authentication.
+ * Application code and interceptors read via `SecurityContext.current()`.
+ */
+export const SecurityContext = {
+  /**
+   * Execute a function with the given principal in scope.
+   * Called by security middleware after authentication.
+   */
+  async run<R>(
+    principal: Principal | undefined,
+    fn: () => R | Promise<R>,
+  ): Promise<R> {
+    const als = await getStorage();
+    return als.run(principal, fn);
+  },
+
+  /**
+   * Get the authenticated principal for the current request.
+   * Returns undefined if not authenticated or not inside a security context.
+   */
+  current(): Principal | undefined {
+    return storage?.getStore();
+  },
+
+  /**
+   * Check if code is running inside a security context.
+   */
+  isActive(): boolean {
+    return storage?.getStore() !== undefined;
+  },
+} as const;

--- a/packages/security/src/security-exception-handler.ts
+++ b/packages/security/src/security-exception-handler.ts
@@ -1,0 +1,23 @@
+import { Singleton } from '@goodie-ts/core';
+import { ExceptionHandler, Response } from '@goodie-ts/http';
+import { ForbiddenError, UnauthorizedError } from './errors.js';
+
+/**
+ * Exception handler for security errors.
+ *
+ * Maps UnauthorizedError to 401 and ForbiddenError to 403.
+ * Extends ExceptionHandler from @goodie-ts/http — auto-discovered
+ * via baseTokenRefs in the exception handling pipeline.
+ */
+@Singleton()
+export class SecurityExceptionHandler extends ExceptionHandler {
+  handle(error: unknown): Response<unknown> | undefined {
+    if (error instanceof UnauthorizedError) {
+      return Response.status(401, { message: error.message });
+    }
+    if (error instanceof ForbiddenError) {
+      return Response.status(403, { message: error.message });
+    }
+    return undefined;
+  }
+}

--- a/packages/security/src/security-interceptor.ts
+++ b/packages/security/src/security-interceptor.ts
@@ -16,6 +16,11 @@ import { SecurityContext } from './security-context.js';
 @Singleton()
 export class SecurityInterceptor implements MethodInterceptor {
   intercept(ctx: InvocationContext): unknown | Promise<unknown> {
+    // @Anonymous methods skip all security checks
+    if (ctx.metadata?.anonymous === true) {
+      return ctx.proceed();
+    }
+
     const principal = SecurityContext.current();
 
     if (!principal) {

--- a/packages/security/src/security-interceptor.ts
+++ b/packages/security/src/security-interceptor.ts
@@ -1,0 +1,42 @@
+import type { InvocationContext, MethodInterceptor } from '@goodie-ts/core';
+import { Singleton } from '@goodie-ts/core';
+import { ForbiddenError, UnauthorizedError } from './errors.js';
+import { SecurityContext } from './security-context.js';
+
+/**
+ * AOP interceptor for @Secured methods.
+ *
+ * Reads the required roles from invocation metadata (set by the @Secured decorator
+ * via the transformer's AOP scanner). Checks the current principal from
+ * SecurityContext. Throws UnauthorizedError if no principal, ForbiddenError
+ * if the principal lacks required roles.
+ *
+ * Works on both controller methods and regular @Singleton bean methods.
+ */
+@Singleton()
+export class SecurityInterceptor implements MethodInterceptor {
+  intercept(ctx: InvocationContext): unknown | Promise<unknown> {
+    const principal = SecurityContext.current();
+
+    if (!principal) {
+      throw new UnauthorizedError();
+    }
+
+    const roles = resolveRoles(ctx.metadata?.roles);
+    if (roles.length > 0) {
+      const hasRole = roles.some((role) => principal.roles.includes(role));
+      if (!hasRole) {
+        throw new ForbiddenError(`Required role(s): ${roles.join(', ')}`);
+      }
+    }
+
+    return ctx.proceed();
+  }
+}
+
+function resolveRoles(raw: unknown): string[] {
+  if (!raw) return [];
+  if (typeof raw === 'string') return [raw];
+  if (Array.isArray(raw)) return raw.filter((r) => typeof r === 'string');
+  return [];
+}

--- a/packages/security/src/security-middleware.ts
+++ b/packages/security/src/security-middleware.ts
@@ -1,0 +1,27 @@
+import type { HttpContext } from '@goodie-ts/http';
+import type { Principal } from './principal.js';
+import { SecurityContext } from './security-context.js';
+import type { SecurityProvider } from './security-provider.js';
+
+/**
+ * Creates a middleware function that authenticates requests via SecurityProviders.
+ *
+ * Iterates all registered providers in order. The first provider that returns
+ * a Principal wins. If no provider authenticates, the principal is undefined
+ * (unauthenticated) — the SecurityInterceptor will throw UnauthorizedError
+ * for @Secured methods.
+ *
+ * The adapter (e.g. hono) is responsible for wiring this into its middleware chain.
+ */
+export function createSecurityMiddleware(
+  providers: SecurityProvider[],
+): (request: HttpContext, next: () => Promise<unknown>) => Promise<unknown> {
+  return async (request: HttpContext, next: () => Promise<unknown>) => {
+    let principal: Principal | undefined;
+    for (const provider of providers) {
+      principal = await provider.authenticate(request);
+      if (principal) break;
+    }
+    return SecurityContext.run(principal, next);
+  };
+}

--- a/packages/security/src/security-provider.ts
+++ b/packages/security/src/security-provider.ts
@@ -1,0 +1,29 @@
+import { InjectionToken } from '@goodie-ts/core';
+import type { HttpContext } from '@goodie-ts/http';
+import type { Principal } from './principal.js';
+
+/**
+ * Abstract security provider. Users implement this to integrate their
+ * authentication mechanism (JWT, session, API key, etc.).
+ *
+ * Multiple providers can be registered — the security middleware
+ * tries each in order and uses the first successful result.
+ */
+export abstract class SecurityProvider {
+  /**
+   * Attempt to authenticate a request.
+   * Returns the authenticated principal, or undefined if this
+   * provider cannot authenticate the request.
+   */
+  abstract authenticate(
+    request: HttpContext,
+  ): Promise<Principal | undefined> | Principal | undefined;
+}
+
+/**
+ * InjectionToken for SecurityProvider — used for collection injection
+ * to discover all registered providers at runtime.
+ */
+export const SECURITY_PROVIDER = new InjectionToken<SecurityProvider>(
+  'SecurityProvider',
+);

--- a/packages/security/tsconfig.json
+++ b/packages/security/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,27 @@ importers:
         specifier: ^24.0.0
         version: 24.0.0
 
+  packages/security:
+    devDependencies:
+      '@goodie-ts/cli':
+        specifier: workspace:*
+        version: link:../cli
+      '@goodie-ts/core':
+        specifier: workspace:*
+        version: link:../core
+      '@goodie-ts/http':
+        specifier: workspace:*
+        version: link:../http
+      '@goodie-ts/transformer':
+        specifier: workspace:*
+        version: link:../transformer
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      ts-morph:
+        specifier: ^24.0.0
+        version: 24.0.0
+
   packages/testing:
     dependencies:
       vitest:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -72,6 +72,14 @@ export default defineConfig({
         __dirname,
         'packages/openapi/src/index.ts',
       ),
+      '@goodie-ts/security/plugin': path.resolve(
+        __dirname,
+        'packages/security/src/plugin.ts',
+      ),
+      '@goodie-ts/security': path.resolve(
+        __dirname,
+        'packages/security/src/index.ts',
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

New `@goodie-ts/security` package providing authentication and authorization for goodie-ts applications.

- `@Secured('ROLE')` AOP decorator with role-based access control via `SecurityInterceptor`
- `@Anonymous()` decorator to exempt methods from security checks
- `SecurityContext` (AsyncLocalStorage) for propagating the authenticated `Principal`
- `SecurityProvider` abstract class for custom authentication strategies
- `SecurityExceptionHandler` maps errors to 401/403 HTTP responses
- `createSecurityMiddleware()` for adapter integration
- Transformer plugin scans `@Secured` roles and `@Anonymous` methods at build time
- Hono adapter discovers security beans via convention (duck typing, no hard dependency)

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (991 tests)
- [x] SecurityInterceptor: unauthorized, no roles, has role, multiple roles, forbidden, proceed
- [x] SecurityExceptionHandler: 401, 403, unknown error, non-Error
- [x] SecurityContext: default undefined, store/retrieve, restore after, nested, unauthenticated
- [x] SecurityMiddleware: authenticated, unauthenticated, first provider wins, passes HttpContext, async
- [x] SecurityPlugin: @Secured class, no roles, array roles, @Anonymous methods, non-secured

🤖 Generated with [Claude Code](https://claude.com/claude-code)